### PR TITLE
Fix flywayInitVersion's type in sample sbt migrate task config

### DIFF
--- a/documentation/sbt/migrate.html
+++ b/documentation/sbt/migrate.html
@@ -256,7 +256,7 @@ flywayCleanOnValidationError := false
 
 flywayInitOnMigrate := false
 
-flywayInitVersion := 5
+flywayInitVersion := "5"
 
 flywayInitDescription := "Let's go!"</pre>
 


### PR DESCRIPTION
`flywayInitVersion`'s value should be [string](https://github.com/flyway/flyway/blob/master/flyway-sbt/src/main/scala/org/flywaydb/sbt/FlywayPlugin.scala#L48).
