### PR TITLE
Remove flywaySettings from sample configurations

### DIFF
--- a/documentation/sbt/baseline.html
+++ b/documentation/sbt/baseline.html
@@ -99,9 +99,7 @@ subtitle: 'sbt flywayBaseline'
         </tbody>
     </table>
     <h2>Sample configuration</h2>
-    <pre class="prettyprint">seq(flywaySettings: _*)
-
-flywayDriver := "org.hsqldb.jdbcDriver"
+    <pre class="prettyprint">flywayDriver := "org.hsqldb.jdbcDriver"
 
 flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 

--- a/documentation/sbt/clean.html
+++ b/documentation/sbt/clean.html
@@ -82,9 +82,7 @@ subtitle: 'sbt flywayClean'
     </table>
 
     <h2>Sample configuration</h2>
-    <pre class="prettyprint">seq(flywaySettings: _*)
-
-flywayDriver := "org.hsqldb.jdbcDriver"
+    <pre class="prettyprint">flywayDriver := "org.hsqldb.jdbcDriver"
 
 flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 

--- a/documentation/sbt/index.html
+++ b/documentation/sbt/index.html
@@ -58,9 +58,7 @@ resolvers += "Flyway" at "https://flywaydb.org/repo"</pre>
     <p>The Flyway SBT plugin can be configured in the following ways:</p>
 
     <h3>Directly in build.sbt</h3>
-    <pre class="prettyprint">seq(flywaySettings: _*)
-
-flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
+    <pre class="prettyprint">flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 
 flywayUser := "SA"
 

--- a/documentation/sbt/info.html
+++ b/documentation/sbt/info.html
@@ -180,9 +180,7 @@ subtitle: 'sbt flywayInfo'
     </table>
 
     <h2>Sample configuration</h2>
-    <pre class="prettyprint">seq(flywaySettings: _*)
-
-flywayDriver := "org.hsqldb.jdbcDriver"
+    <pre class="prettyprint">flywayDriver := "org.hsqldb.jdbcDriver"
 
 flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 

--- a/documentation/sbt/migrate.html
+++ b/documentation/sbt/migrate.html
@@ -254,9 +254,7 @@ subtitle: 'sbt flywayMigrate'
 </table>
 
 <h2>Sample configuration</h2>
-<pre class="prettyprint">seq(flywaySettings: _*)
-
-flywayDriver := "org.hsqldb.jdbcDriver"
+<pre class="prettyprint">flywayDriver := "org.hsqldb.jdbcDriver"
 
 flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 

--- a/documentation/sbt/repair.html
+++ b/documentation/sbt/repair.html
@@ -168,9 +168,7 @@ subtitle: 'sbt flywayRepair'
     </table>
 
     <h2>Sample configuration</h2>
-    <pre class="prettyprint">seq(flywaySettings: _*)
-
-flywayDriver := "org.hsqldb.jdbcDriver"
+    <pre class="prettyprint">flywayDriver := "org.hsqldb.jdbcDriver"
 
 flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 

--- a/documentation/sbt/validate.html
+++ b/documentation/sbt/validate.html
@@ -206,9 +206,7 @@ subtitle: 'sbt flywayValidate'
         </tbody>
     </table>
     <h2>Sample configuration</h2>
-    <pre class="prettyprint">seq(flywaySettings: _*)
-
-flywayDriver := "org.hsqldb.jdbcDriver"
+    <pre class="prettyprint">flywayDriver := "org.hsqldb.jdbcDriver"
 
 flywayUrl := "jdbc:hsqldb:file:target/flyway_sample;shutdown=true"
 


### PR DESCRIPTION
In version 4.0, flywaySettings was removed in favor of a
projectSettings override def.
