### PR TITLE
Update the driver for Google Cloud SQL

### DIFF
--- a/documentation/database/googleCloudSql.html
+++ b/documentation/database/googleCloudSql.html
@@ -8,7 +8,7 @@ subtitle: Google Cloud SQL
 
     <h2>Default Driver</h2>
     <ul>
-        <li>com.google.appengine.api.rdbms.AppEngineDriver</li>
+        <li>com.mysql.jdbc.Driver</li>
     </ul>
 
     <h2><a name="Sql_Script_Syntax"></a>Sql Script Syntax<a href="#Sql_Script_Syntax" class="section_anchor"></a></h2>


### PR DESCRIPTION
Google Cloud SQL is supporting the regular MySQL drivers over IP for a while. The connectivity from App Engine is still special though.

References:

  https://cloud.google.com/sql/docs/external
  https://cloud.google.com/sql/docs/dev-access
  https://cloud.google.com/appengine/docs/java/cloud-sql/#Java_Connect_to_your_database
