### PR TITLE
correct typo in markdown hyperlinks

### DIFF
--- a/documentation/commandline/index.md
+++ b/documentation/commandline/index.md
@@ -102,8 +102,8 @@ These different means of configuration can be combined at will.
 
 ### Config files
 
-[Config files](/documentaion/configfiles) are supported by the Flyway command-line tool. If you are not familiar with them,
-check out the [Flyway config file structure and settings reference](/documentaion/configfiles) first.
+[Config files](/documentation/configfiles) are supported by the Flyway command-line tool. If you are not familiar with them,
+check out the [Flyway config file structure and settings reference](/documentation/configfiles) first.
 
 Flyway will search for and automatically load the following config files if present:
 - `<install-dir>/conf/flyway.conf`

--- a/documentation/gradle/index.md
+++ b/documentation/gradle/index.md
@@ -179,8 +179,8 @@ Configuration can also be supplied directly via the command-line using JVM syste
 
 ### Config files
 
-[Config files](/documentaion/configfiles) are supported by the Flyway Gradle plugin. If you are not familiar with them,
-check out the [Flyway config file structure and settings reference](/documentaion/configfiles) first.
+[Config files](/documentation/configfiles) are supported by the Flyway Gradle plugin. If you are not familiar with them,
+check out the [Flyway config file structure and settings reference](/documentation/configfiles) first.
 
 Flyway will search for and automatically load the `<user-home>/flyway.conf` config file if present.
 

--- a/documentation/maven/index.md
+++ b/documentation/maven/index.md
@@ -231,8 +231,8 @@ Configuration can also be supplied directly via the command-line using JVM syste
 
 ### Config files
 
-[Config files](/documentaion/configfiles) are supported by the Flyway Maven plugin. If you are not familiar with them,
-check out the [Flyway config file structure and settings reference](/documentaion/configfiles) first.
+[Config files](/documentation/configfiles) are supported by the Flyway Maven plugin. If you are not familiar with them,
+check out the [Flyway config file structure and settings reference](/documentation/configfiles) first.
 
 Flyway will search for and automatically load the `<user-home>/flyway.conf` config file if present.
 


### PR DESCRIPTION
The misspelling of "documentation" broke a few links. This type of error can probably be caught by Jekyll, but I don't know enough about your site's build process to suggest a general solution.