### PR TITLE
Add workaround for limitation

### DIFF
--- a/documentation/database/sqlserver.md
+++ b/documentation/database/sqlserver.md
@@ -120,7 +120,8 @@ INSERT INTO ${tableName} (name) VALUES (&#x27;Mr. T&#x27;);</pre>
 
 ## Limitations
 
-- When setting `flyway.schemas`, the first schema is not set as the default due to [SQL Server limitations](http://connect.microsoft.com/SQLServer/feedback/details/390528/t-sql-statement-for-changing-default-schema-context)
+- When setting `flyway.schemas`, the first schema is not set as the default due to [SQL Server limitations](http://connect.microsoft.com/SQLServer/feedback/details/390528/t-sql-statement-for-changing-default-schema-context). 
+  [Placeholders](https://flywaydb.org/documentation/migrations#placeholder-replacement) can be used to work around this limitation.
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/database/db2">DB2 <i class="fa fa-arrow-right"></i></a>


### PR DESCRIPTION
It took me considerable effort to find out that using both the schemas option and an additional placeholder with the schema name is the way to parameterize the schema name in a sql server setup, so I think it is best added to the documentation so that other won't have to struggle with the same issue.