### PR TITLE
Additional documentation note

### DIFF
--- a/documentation/migrations.md
+++ b/documentation/migrations.md
@@ -353,6 +353,9 @@ public class V1_2__Another_user extends BaseJavaMigration {
 }
 ```
 
+Take care that your Java migration does not close the database connection, either explicitly or as a
+result of a try-with-resources statement.
+
 ### Spring
 
 If your application already uses Spring and you do not want to use JDBC directly you can easily use Spring JDBC's


### PR DESCRIPTION
At least one user has fallen over on a Java migration with

`try(Connection c = context.getConnection()) { ... }`

which closes the database connection before Flyway has finished with it. This note might help?