### PR TITLE
Update mariadb url format to reflect what is possible

### DIFF
--- a/documentation/database/mariadb.md
+++ b/documentation/database/mariadb.md
@@ -23,7 +23,7 @@ subtitle: MariaDB
 <table class="table">
 <tr>
 <th>URL format</th>
-<td><code>jdbc:mariadb://<i>host</i>:<i>port</i>/<i>database</i></code></td>
+<td><code>jdbc:(mysql|mariadb)://<i>host</i>:<i>port</i>/<i>database</i></code></td>
 </tr>
 <tr>
 <th>Ships with Flyway Command-line</th>


### PR DESCRIPTION
as established in https://github.com/flyway/flyway/issues/2481, flyway supports both `jdbc:mysql` and `jdbc:mariadb` prefixes in database URLs.