### PR TITLE
Adopt Dockerized Jekyll setup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+indent_size = 4

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+ifeq ($(OS), Windows_NT)
+FORCE_POLLING = true
+else
+FORCE_POLLING = false
+endif
+
+all: clean run
+
+clean:
+	docker run --rm -v "$(realpath .):/app" bash \
+		rm -rf /app/_site
+
+run:
+	docker run --rm \
+		-v "$(realpath .):/srv/jekyll" \
+		-p 35729:35729 -p 4000:4000 \
+		-e FORCE_POLLING=$(FORCE_POLLING) \
+		-e PAGES_REPO_NWO='flyway/flywaydb.org' \
+		-it jekyll/jekyll:3.8 \
+		jekyll serve --livereload --incremental

--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This is the code for Flyway's website hosted at <https://flywaydb.org>
 
 ## Contributing
 
-Want to contribute? Great! Simply submit a pull request. We'll review it and merge it if accepted.
+Want to [contribute](https://flywaydb.org/documentation/contribute/website/)? Great! Simply submit a pull request. We'll review it and merge it if accepted.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-flywaydb.org
-============
+# flywaydb.org
 
-This is the code for Flyway's website hosted at https://flywaydb.org
+This is the code for Flyway's website hosted at <https://flywaydb.org>
 
-Contributing
-------------
+## Contributing
 
 Want to contribute? Great! Simply submit a pull request. We'll review it and merge it if accepted.

--- a/_run-dockerized.cmd
+++ b/_run-dockerized.cmd
@@ -1,2 +1,0 @@
-@echo off
-docker run --rm -v "%CD%:/srv/jekyll" -p 35729:35729 -p 4000:4000 -e PAGES_REPO_NWO='flyway/flywaydb.org' -it jekyll/jekyll:3.8 jekyll serve --livereload --incremental --force_polling

--- a/_run.cmd
+++ b/_run.cmd
@@ -1,6 +1,0 @@
-@echo off
-rem In case eventmachine fails to load:
-rem gem uninstall eventmachine
-rem gem install eventmachine --platform=ruby
-set PAGES_REPO_NWO=flyway/flywaydb.org
-bundle exec jekyll serve -w -L

--- a/_run.sh
+++ b/_run.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-docker run --rm \
-  -v "$(PWD):/srv/jekyll" \
-  -p 35729:35729 -p 4000:4000 \
-  -e PAGES_REPO_NWO='flyway/flywaydb.org' \
-  -it jekyll/jekyll:3.8 \
-  jekyll serve --livereload --incremental

--- a/documentation/contribute/website/setup.html
+++ b/documentation/contribute/website/setup.html
@@ -9,49 +9,26 @@ subtitle: Dev Environment Setup - Website
     <p>To contribute to the Flyway website you will need to set up your development environment so that you run the
         website locally and submit changes. </p>
 
-    <p>For this you will need to set up Git, Ruby, the Ruby Dev Kit, Jekyll and an editor.</p>
+    <p>For this you will need to set up Git, Make, Docker and an editor.</p>
 
-    <h2>Git</h2>
+    <h2>Prerequisites</h2>
 
-    <p>The Flyway website is developed using Git for version control, just like Flyway itself. Download the latest
-        version here: <a
-                href="http://msysgit.github.com/"
-                >http://msysgit.github.com/</a></p>
+    <ul>
+        <li><a href="https://git-scm.com/downloads">Git</a></li>
+        <li><a href="https://docs.docker.com/install/">Docker</a></li>
+        <li>
+            Make:
+            <ul>
+                <li>Windows: <code>choco install make</code></li>
+                <li>Ubuntu: <code>sudo apt install make</code></li>
+                <li>macOS: <code>xcode-select --install</code> (available as part of the Command Line Tools for Xcode)</li>
+            </ul>
+        </li>
+    </ul>
 
-    <p>Make sure the directory containing the binaries has been added the PATH. If you downloaded an installer this
-        should have been taken care of for you.</p>
+    <h3>Editor</h3>
 
-    <h2>Ruby</h2>
-
-    <p>In order to install and run Jekyll you need a working Ruby installation.</p>
-
-    <p>You can find the latest version of the RubyInstaller here:
-        <a href="http://rubyinstaller.org/downloads/">http://rubyinstaller.org/downloads/</a>.</p>
-
-    <p>Make sure the directory containing the binaries has been added the PATH. If you downloaded the installer this
-        should have been taken care of for you.</p>
-
-    <h2>Ruby Dev Kit</h2>
-
-    <p>In order to install and run Jekyll you also need a Ruby Development Kit installation.</p>
-
-    <p>Make sure to pick the version matching the Ruby version you just installed. You can find it here:
-        <a href="http://rubyinstaller.org/downloads/">http://rubyinstaller.org/downloads/</a>.</p>
-
-    <p>Unzip in a folder and then open a command-line prompt there to execute:</p>
-    <pre class="console">&gt; ruby dk.rb init</pre>
-    <p>followed by</p>
-    <pre class="console">&gt; ruby dk.rb install</pre>
-
-    <h2>Jekyll</h2>
-
-    <p>To generate the static website from the Git repository we use Jekyll. You can install the latest version like
-        this:</p>
-    <pre class="console">&gt; gem install jekyll</pre>
-
-    <h2>Editor</h2>
-
-    <p>The website uses html files with Liquid headers for Jekyll. We personally use IntelliJ, which works quite well,
+    <p>The website uses HTML files with Liquid headers for Jekyll. We personally use IntelliJ, which works quite well,
         but feel free to use any editor that suits you.</p>
 
     <h2>Done!</h2>

--- a/documentation/contribute/website/submit.html
+++ b/documentation/contribute/website/submit.html
@@ -26,7 +26,8 @@ subtitle: Submit your Changes - Website
         and merge the changes from the main repo as they happen.</p>
 
     <p>To view your changes locally you can execute this command in the root of your working copy:</p>
-    <pre class="console">&gt; jekyll serve -w</pre>
+    <pre class="console">&gt; make</pre>
+    <p>Once the server is running, the local version of the website will be available at <a href="http://localhost:4000/">http://localhost:4000/</a>.</p>
 
     <h2>Publish your changes</h2>
 


### PR DESCRIPTION
In order to avoid having to install Jekyll and all its dependencies, we've been experimenting with using a Dockerized version of Jekyll, which has been working quite well.

This pull request adopts that setup and also updates the [website contributing guide](https://flywaydb.org/documentation/contribute/website/). We're using a `Makefile` so that we don't have to maintain platform-specific scripts.