### PR TITLE
Fix broken Spring integration references

### DIFF
--- a/documentation/plugins/grails.md
+++ b/documentation/plugins/grails.md
@@ -7,7 +7,7 @@ subtitle: 'Grails'
 
 <img src="/assets/logos/grails.png">
 
-Grails 3.x is based on Spring Boot comes with out-of-the-box <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/howto-database-initialization.html#howto-execute-flyway-database-migrations-on-startup">integration for Flyway</a>.
+Grails 3.x is based on Spring Boot comes with out-of-the-box <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-execute-flyway-database-migrations-on-startup">integration for Flyway</a>.
 
 All you need to do is add `flyway-core` to your `build.gradle`:
 <pre class="prettyprint">compile "org.flywaydb:flyway-core:{{ site.flywayVersion }}"</pre>

--- a/documentation/plugins/springboot.md
+++ b/documentation/plugins/springboot.md
@@ -7,7 +7,7 @@ subtitle: 'Spring Boot'
 
 <img src="/assets/logos/springboot.png" style="margin-bottom: 20px">
 
-Spring Boot comes with out-of-the-box <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/howto-database-initialization.html#howto-execute-flyway-database-migrations-on-startup">integration for Flyway</a>.
+Spring Boot comes with out-of-the-box <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-execute-flyway-database-migrations-on-startup">integration for Flyway</a>.
 
 All you need to do is add `flyway-core` to either your `pom.xml`:
 ```xml


### PR DESCRIPTION
The **integration for Flyway** links on both the **springboot** and **grails** plugins page are broken:
https://flywaydb.org/documentation/plugins/grails
https://flywaydb.org/documentation/plugins/springboot

They currently point to:
https://docs.spring.io/spring-boot/docs/current/reference/html/howto-database-initialization.html#howto-execute-flyway-database-migrations-on-startup

It appears Spring consolidated their "How To's" into a single "howto.html" file, so the correct reference is now:
https://docs.spring.io/spring-boot/docs/current/reference/html/howto.html#howto-execute-flyway-database-migrations-on-startup