### PR TITLE
"Flyway by Redgate"

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -115,6 +115,9 @@ title: Documentation
                     {% if page.menu == 'derby' %} class="active" {% endif %}>
                     <a href="/documentation/database/derby">Derby</a></li>
                     <li
+                    {% if page.menu == 'snowflake' %} class="active" {% endif %}>
+                    <a href="/documentation/database/snowflake">Snowflake</a></li>
+                    <li
                     {% if page.menu == 'sqlite' %} class="active" {% endif %}>
                     <a href="/documentation/database/sqlite">SQLite</a></li>
                     <li

--- a/documentation/commandline/baseline.md
+++ b/documentation/commandline/baseline.md
@@ -124,7 +124,7 @@ flyway.baselineDescription=Base Migration
 ## Sample output
 <pre class="console">&gt; flyway baseline
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Creating schema history table: "PUBLIC"."flyway_schema_history"
 Schema baselined with version: 1</pre>

--- a/documentation/commandline/clean.md
+++ b/documentation/commandline/clean.md
@@ -103,7 +103,7 @@ flyway.cleanDisabled=false
 ## Sample output
 <pre class="console">&gt; flyway clean
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Cleaned database schema 'PUBLIC' (execution time 00:00.014s)</pre>
 

--- a/documentation/commandline/info.md
+++ b/documentation/commandline/info.md
@@ -220,7 +220,7 @@ flyway.outOfOrder=false
 
 <pre class="console">&gt; flyway info
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Database: jdbc:h2:file:flyway.db (H2 1.3)
 

--- a/documentation/commandline/repair.md
+++ b/documentation/commandline/repair.md
@@ -210,7 +210,7 @@ flyway.skipDefaultCallbacks=false
 
 <pre class="console">&gt; flyway repair
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Repair not necessary. No failed migration detected.</pre>
 

--- a/documentation/commandline/undo.md
+++ b/documentation/commandline/undo.md
@@ -287,7 +287,7 @@ flyway.oracle.sqlplusWarn=true
 
 <pre class="console">&gt; flyway undo
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Database: jdbc:h2:file:C:\Programs\flyway-0-SNAPSHOT\flyway.db (H2 1.3)
 Current version of schema "PUBLIC": 1

--- a/documentation/commandline/validate.md
+++ b/documentation/commandline/validate.md
@@ -273,7 +273,7 @@ flyway.oracle.sqlplusWarn=true
 
 <pre class="console">&gt; flyway validate
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 No migrations applied yet. No validation necessary.</pre>
 

--- a/documentation/database/derby.md
+++ b/documentation/database/derby.md
@@ -72,5 +72,5 @@ INSERT INTO ${tableName} (name) VALUES ('Mr. T');
 - *None*
 
 <p class="next-steps">
-    <a class="btn btn-primary" href="/documentation/database/sqlite">SQLite <i class="fa fa-arrow-right"></i></a>
+    <a class="btn btn-primary" href="/documentation/database/snowflake">Snowflake <i class="fa fa-arrow-right"></i></a>
 </p>

--- a/documentation/database/snowflake.md
+++ b/documentation/database/snowflake.md
@@ -1,0 +1,72 @@
+---
+layout: documentation
+menu: snowflake
+subtitle: Snowflake
+---
+# Snowflake
+
+## Supported Versions
+
+- `3.50` and later `3.x` versions
+
+## Drivers
+
+<table class="table">
+<tr>
+<th>URL format</th>
+<td><code>jdbc:snowflake://<i>account</i>.snowflakecomputing.com/?db=<i>database</i>&warehouse=<i>warehouse</i>&role=<i>role</i></code>
+(optionally <code>&schema=<i>schema</i></code> to specify current schema)</td>
+</tr>
+<tr>
+<th>Ships with Flyway Command-line</th>
+<td>No</td>
+</tr>
+<tr>
+<th>Maven Central coordinates</th>
+<td><code>net.snowflake:snowflake-jdbc:3.6.23</code></td>
+</tr>
+<tr>
+<th>Supported versions</th>
+<td><code>3.6.23</code> and later</td>
+</tr>
+<tr>
+<th>Default Java class</th>
+<td><code>net.snowflake.client.jdbc.SnowflakeDriver</code></td>
+</tr>
+</table>
+
+## SQL Script Syntax
+
+- [Standard SQL syntax](/documentation/migrations#sql-based-migrations#syntax) with statement delimiter **;**
+
+### Compatibility
+
+- DDL exported by the Snowflake web GUI can be used unchanged in a Flyway migration
+- Any SQL script executed by Flyway, can be executed by the Snowflake web GUI (after the placeholders have been replaced)
+- The Snowflake driver requires Java 8+. There is no support from Snowflake for Java 7 users.
+
+### Example
+
+<pre class="prettyprint">/* Single line comment */
+CREATE TABLE test_data (
+  value VARCHAR(25) NOT NULL PRIMARY KEY
+);
+
+/*
+Multi-line
+comment
+*/
+
+-- Sql-style comment
+
+-- Placeholder
+INSERT INTO ${tableName} (name) VALUES ('Mr. T');
+</pre>
+
+## Limitations
+
+- *None*
+
+<p class="next-steps">
+    <a class="btn btn-primary" href="/documentation/database/sqlite">SQLite <i class="fa fa-arrow-right"></i></a>
+</p>

--- a/documentation/gradle/migrate.md
+++ b/documentation/gradle/migrate.md
@@ -361,8 +361,9 @@ flyway {
 }
 ```
 
-<h2>Sample output</h2>
-<pre class="console">&gt; gradle flywayMigrate -i
+## Sample output
+
+<pre class="console">> gradle flywayMigrate -i
 
 Current schema version: 0
 Migrating to version 1

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -64,6 +64,7 @@ title: Documentation
     <a href="/documentation/database/h2">H2</a>,
     <a href="/documentation/database/hsqldb">HSQLDB</a>,
     <a href="/documentation/database/derby">Derby</a>,
+    <a href="/documentation/database/snowflake">Snowflake</a>,
     <a href="/documentation/database/sqlite">SQLite</a> and
     <a href="/documentation/database/firebird">Firebird</a>.</p>
 

--- a/documentation/releaseNotes.html
+++ b/documentation/releaseNotes.html
@@ -12,6 +12,7 @@ subtitle: Release Notes
     <h3>New features</h3>
     <ul>
         {% include issue.html id="1479" title="Environment variable substitution in config files" %}
+        {% include issue.html id="1735" title="Snowflake support" %}
         {% include issue.html id="2532" title="H2 1.4.200 support" %}
     </ul>
 
@@ -22,7 +23,8 @@ subtitle: Release Notes
     </ul>
 
     <p>
-        Thanks to David Campbell, fanticat, Gavin Figueroa, jshayward (no relation!) and NEzer2 for reporting these issues and/or submitting pull requests.
+        Thanks to Bob Tierney, David Campbell, fanticat, Gavin Figueroa, jshayward (no relation!), Mike Breault, NEzer2
+        and rjungwirth for reporting these issues and/or submitting pull requests.
     </p>
 </div>
 

--- a/documentation/releaseNotes.html
+++ b/documentation/releaseNotes.html
@@ -8,6 +8,22 @@ subtitle: Release Notes
 <p>Thank you all for reporting all these issues and contributing fixes!</p>
 
 <div class="release">
+    <h2 id="6.1.0">Flyway 6.1 (unreleased)</h2>
+    <h3>New features</h3>
+    <ul>
+        {% include issue.html id="1479" title="Environment variable substitution in config files" %}
+    </ul>
+
+    <h3>Bug fixes</h3>
+    <ul>
+    </ul>
+
+    <p>
+        Thanks to ????? for reporting these issues and/or submitting pull requests.
+    </p>
+</div>
+
+<div class="release">
     <h2 id="6.0.8">Flyway 6.0.8 (2019-10-30)</h2>
     <h3>Bug fixes</h3>
     <ul>
@@ -19,7 +35,9 @@ subtitle: Release Notes
     <p>
         Thanks to David Atkinson, Niklas Lochschmidt, Seb Urbaniak and Tadayuki Onishi for reporting these issues and/or submitting pull requests.
     </p>
+</div>
 
+<div class="release">
     <h2 id="6.0.7">Flyway 6.0.7 (2019-10-17)</h2>
     <h3>Bug fixes</h3>
     <ul>
@@ -32,7 +50,9 @@ subtitle: Release Notes
     <p>
         Thanks to bramant, Matonen and stevenenen for reporting these issues and/or submitting pull requests.
     </p>
+</div>
 
+<div class="release">
     <h2 id="6.0.6">Flyway 6.0.6 (2019-10-09)</h2>
 
     <h3>New features</h3>

--- a/documentation/releaseNotes.html
+++ b/documentation/releaseNotes.html
@@ -12,15 +12,17 @@ subtitle: Release Notes
     <h3>New features</h3>
     <ul>
         {% include issue.html id="1479" title="Environment variable substitution in config files" %}
+        {% include issue.html id="2532" title="H2 1.4.200 support" %}
     </ul>
 
     <h3>Bug fixes</h3>
     <ul>
+        {% include issue.html id="1466" title="Classpath scanning results are cached between migrate runs" %}
         {% include issue.html id="2535" title="CREATE TABLE ... AS SELECT not allowed in MySQL when enforcing GTID consistency" %}
     </ul>
 
     <p>
-        Thanks to David Campbell, fanticat, Gavin Figueroa and NEzer2 for reporting these issues and/or submitting pull requests.
+        Thanks to David Campbell, fanticat, Gavin Figueroa, jshayward (no relation!) and NEzer2 for reporting these issues and/or submitting pull requests.
     </p>
 </div>
 

--- a/documentation/releaseNotes.html
+++ b/documentation/releaseNotes.html
@@ -16,10 +16,11 @@ subtitle: Release Notes
 
     <h3>Bug fixes</h3>
     <ul>
+        {% include issue.html id="2535" title="CREATE TABLE ... AS SELECT not allowed in MySQL when enforcing GTID consistency" %}
     </ul>
 
     <p>
-        Thanks to ????? for reporting these issues and/or submitting pull requests.
+        Thanks to David Campbell, fanticat, Gavin Figueroa and NEzer2 for reporting these issues and/or submitting pull requests.
     </p>
 </div>
 

--- a/documentation/releaseNotes.html
+++ b/documentation/releaseNotes.html
@@ -11,6 +11,7 @@ subtitle: Release Notes
     <h2 id="6.1.0">Flyway 6.1 (unreleased)</h2>
     <h3>New features</h3>
     <ul>
+        {% include issue.html id="1384" title="Special automatically-populated <code>FLYWAY.CURRENT_SCHEMA</code> placeholder" %}
         {% include issue.html id="1479" title="Environment variable substitution in config files" %}
         {% include issue.html id="1735" title="Snowflake support" %}
         {% include issue.html id="2532" title="H2 1.4.200 support" %}
@@ -19,7 +20,9 @@ subtitle: Release Notes
     <h3>Bug fixes</h3>
     <ul>
         {% include issue.html id="1466" title="Classpath scanning results are cached between migrate runs" %}
-        {% include issue.html id="2535" title="CREATE TABLE ... AS SELECT not allowed in MySQL when enforcing GTID consistency" %}
+        {% include issue.html id="2535" title="</code>CREATE TABLE ... AS SELECT</code> not allowed in MySQL when enforcing GTID consistency" %}
+        {% include issue.html id="2550" title="Oracle SQL*Plus: </code>SET ECHO ON</code> should echo to Flyway's output" %}
+        {% include issue.html id="2553" title="Error message improved when script is incorrectly named" %}
     </ul>
 
     <p>
@@ -33,7 +36,7 @@ subtitle: Release Notes
     <h3>Bug fixes</h3>
     <ul>
         {% include issue.html id="2537" title="Unexpected error re. non-empty schemas" %}
-        {% include issue.html id="2539" title="HSQLDB: Unable to parse `DROP INDEX IF EXISTS` statement" %}
+        {% include issue.html id="2539" title="HSQLDB: Unable to parse </code>DROP INDEX IF EXISTS</code> statement" %}
         {% include issue.html id="2542" title="MS-SQL stored proc calls cause non-transactional statement error." %}
     </ul>
 

--- a/download/index.md
+++ b/download/index.md
@@ -35,7 +35,7 @@ Choose your Flyway edition based on the features and support level you require
 <tr><td>Batching</td><td></td><td><i class="fa fa-check"></i></td><td><i class="fa fa-check"></i></td></tr>
 <tr><td>Streaming</td><td></td><td><i class="fa fa-check"></i></td><td><i class="fa fa-check"></i></td></tr>
 <tr><td><a href="/documentation/migrations#query-results">Toggle display of query results</a></td><td></td><td><i class="fa fa-check"></i></td><td><i class="fa fa-check"></i></td></tr>
-<tr><td>Java 7 compatibility</td><td></td><td></td><td><i class="fa fa-check"></i></td></tr>
+<tr><td>Java 7 compatibility</td><td></td><td></td><td><i class="fa fa-check"></i><br><span class="note">Subject to driver availability</span></td></tr>
 <tr><td>License</td><td><a href="/licenses/flyway-community">Apache v2</a></td><td><a href="/licenses/flyway-pro">Commercial</a></td><td><a href="/licenses/flyway-enterprise">Commercial</a></td></tr>
 <tr><td>Maven Repository</td><td><i class="fa fa-check"></i></td><td><i class="fa fa-check"></i></td><td><i class="fa fa-check"></i></td></tr>
 <tr><td>Source Code included</td><td><i class="fa fa-check"></i></td><td><i class="fa fa-check"></i></td><td><i class="fa fa-check"></i></td></tr>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,7 @@ tab: home
         <div class="col-md-4">
             <div class="marketing-item"><i class="fa fa-check-circle-o"></i> Zero required dependencies</div>
 
-            <p>All you need is Java 6+ and your Jdbc driver and you're good to go!</p>
+            <p>All you need is Java 7+ and your Jdbc driver and you're good to go!</p>
         </div>
     </div>
     <div class="row">
@@ -276,6 +276,10 @@ tab: home
         </div>
         <div class="col-md-2">
             <div class="marketing-item"><i class="fa fa-database"></i> <a href="/documentation/database/derby">Derby</a>
+            </div>
+        </div>
+        <div class="col-md-2">
+            <div class="marketing-item"><i class="fa fa-database"></i> <a href="/documentation/database/snowflake">Snowflake</a>
             </div>
         </div>
         <div class="col-md-2">


### PR DESCRIPTION
The commandline produces output like

`Flyway 6.0.8 by Redgate`

so update the documentation to reflect this. Also fix a formatting inconsistency in Gradle docs 