### PR TITLE
Command line says "Flyway by Redgate" now

### DIFF
--- a/documentation/commandline/baseline.md
+++ b/documentation/commandline/baseline.md
@@ -124,7 +124,7 @@ flyway.baselineDescription=Base Migration
 ## Sample output
 <pre class="console">&gt; flyway baseline
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Creating schema history table: "PUBLIC"."flyway_schema_history"
 Schema baselined with version: 1</pre>

--- a/documentation/commandline/clean.md
+++ b/documentation/commandline/clean.md
@@ -103,7 +103,7 @@ flyway.cleanDisabled=false
 ## Sample output
 <pre class="console">&gt; flyway clean
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Cleaned database schema 'PUBLIC' (execution time 00:00.014s)</pre>
 

--- a/documentation/commandline/info.md
+++ b/documentation/commandline/info.md
@@ -220,7 +220,7 @@ flyway.outOfOrder=false
 
 <pre class="console">&gt; flyway info
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Database: jdbc:h2:file:flyway.db (H2 1.3)
 

--- a/documentation/commandline/repair.md
+++ b/documentation/commandline/repair.md
@@ -210,7 +210,7 @@ flyway.skipDefaultCallbacks=false
 
 <pre class="console">&gt; flyway repair
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Repair not necessary. No failed migration detected.</pre>
 

--- a/documentation/commandline/undo.md
+++ b/documentation/commandline/undo.md
@@ -287,7 +287,7 @@ flyway.oracle.sqlplusWarn=true
 
 <pre class="console">&gt; flyway undo
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 Database: jdbc:h2:file:C:\Programs\flyway-0-SNAPSHOT\flyway.db (H2 1.3)
 Current version of schema "PUBLIC": 1

--- a/documentation/commandline/validate.md
+++ b/documentation/commandline/validate.md
@@ -273,7 +273,7 @@ flyway.oracle.sqlplusWarn=true
 
 <pre class="console">&gt; flyway validate
 
-Flyway {{ site.flywayVersion }} by Boxfuse
+Flyway {{ site.flywayVersion }} by Redgate
 
 No migrations applied yet. No validation necessary.</pre>
 

--- a/documentation/gradle/migrate.md
+++ b/documentation/gradle/migrate.md
@@ -361,8 +361,9 @@ flyway {
 }
 ```
 
-<h2>Sample output</h2>
-<pre class="console">&gt; gradle flywayMigrate -i
+## Sample output
+
+<pre class="console">> gradle flywayMigrate -i
 
 Current schema version: 0
 Migrating to version 1


### PR DESCRIPTION
The commandline produces output like

Flyway 6.0.8 by Redgate

so update the documentation to reflect this. Also fix a formatting inconsistency in Gradle docs