### PR TITLE
Fix link to next page in documentation

### DIFF
--- a/documentation/migrations.md
+++ b/documentation/migrations.md
@@ -447,5 +447,5 @@ When Flyway discovers an applied versioned migration with a version that is high
 (this happens typically when a newer version of the software has migrated that schema), that migration is marked as **future**.
 
 <p class="next-steps">
-    <a class="btn btn-primary" href="/documentation/configuration">Configuration <i class="fa fa-arrow-right"></i></a>
+    <a class="btn btn-primary" href="/documentation/callbacks">Callbacks <i class="fa fa-arrow-right"></i></a>
 </p>


### PR DESCRIPTION
There is no Configuration page; /documentation/configuration does not exist. Changing to Callbacks (assuming that the left hand menus indicate the proper flow).