### PR TITLE
Wait a second before doing the trial form POST request

### DIFF
--- a/_includes/trialpopup.html
+++ b/_includes/trialpopup.html
@@ -32,7 +32,12 @@
 
     // On a successful submission, hide and submit trial form.
     marketoForm.onSuccess(function(formData) {
-        hideAndSubmitTrialForm(formData);
+        // Wait a second to give Marketo time to enter the person into the database
+        // before doing the POST request in hideAndSubmitTrialForm().
+        window.setTimeout(function(){
+            hideAndSubmitTrialForm(formData);
+        }, 1000);
+        
         return false;
     });
 });</script>


### PR DESCRIPTION
So that Marketo has time to enter the person into the database, if they’re not already in there.

We've seen a bug this morning where the trial license information wasn't being inserted into the Marketo database, and this was because the person information hadn't been entered (from the form submission step) yet, before the attempt to add the license key to the person.

@juliahayward was working on the API endpoint for me, and if she's not able to add checking there, then please deploy this update to add a delay on the front-end.