### PR TITLE
Office hours banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -64,7 +64,11 @@
     <script src="/assets/jquery-1.12.1/jquery-1.12.1.min.js" type="text/javascript"></script>
 </head>
 <body class="{{layout.tab}} {{page.tab}}">
+    <div class="oh-notification">
+        <p><strong>Looking for updates?</strong> Office Hours are this Wednesday 20th May, 15:00 UTC <a href="https://redgate.zoom.us/webinar/register/WN_dimdjBWmTAyds4RbFkApdQ" class="oh-button">Join in</a></p>  
+    </div>
 <div class="container">
+   
     <div id="header" class="row">
         <div class="col-md-2">
             {% if page.tab != 'home' %}<a href="/"><img src="/assets/logo/flyway-logo-tm-sm.png" alt="Flyway" usemap="#logosmmap"/>

--- a/assets/flywaydb.css
+++ b/assets/flywaydb.css
@@ -999,3 +999,21 @@ body.download #newsletter-sign-up h3 {
 #flyway-trial-license-modal .mktoForm .mktoRequiredField label:after {
     content: ' (required)';
 }
+
+.oh-notification {
+    background: #0166AE; 
+    text-align: center;
+    padding: 16px 10px 10px;
+}
+
+.oh-notification p {
+    color: #ffffff;
+}
+
+.oh-notification a {
+    background: #ffffff;
+    padding: 6px;
+    margin: 2px 4px 0px;
+    border-radius: 5px;
+}
+


### PR DESCRIPTION
A banner to live at the top of the flyway website notifying the community of our upcoming office hours. Tested in Safari, Firefox and Chrome (MacOS). 

Will need to be taken down after 20th May.

![Screenshot 2020-05-14 at 13 34 24](https://user-images.githubusercontent.com/13132227/81935136-0958fe80-95e8-11ea-94cf-b02039cca783.png)
