### PR TITLE
Added Webinar Banner

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -64,6 +64,9 @@
     <script src="/assets/jquery-1.12.1/jquery-1.12.1.min.js" type="text/javascript"></script>
 </head>
 <body class="{{layout.tab}} {{page.tab}}">
+    <div class="oh-notification">
+        <p><strong>Looking to achieve DevOps with Flyway?</strong> Join our Flyway webinar - July 29th 16:00 BST / 8 AM PDT <a href="https://www.red-gate.com/hub/events/online-events/embracing-devops-through-database-migrations-with-flyway" class="oh-button">Join in</a></p>  
+    </div>
 <div class="container">
    
     <div id="header" class="row">


### PR DESCRIPTION
A banner to live at the top of the flyway website notifying the community of our upcoming webinar. Tested in Safari and Chrome (MacOS).

Will need to be taken down after 29th July.

![Screenshot 2020-07-09 at 13 03 57](https://user-images.githubusercontent.com/68007296/87037866-d47eb780-c1e4-11ea-82a1-7a7e736adabe.png)
