### PR TITLE
Capture downloaders details

### DIFF
--- a/_includes/downloadpopup.html
+++ b/_includes/downloadpopup.html
@@ -1,4 +1,14 @@
-<div class="modal fade" id="download-email-modal-{{ include.id }}" tabindex="-1" role="dialog">
+<style>
+    .download-email-modal form {font-size:14px !important; width:auto !important;}
+    .download-email-modal label {width:125px !important;}
+    .download-email-modal .mktoOffset {display: none;}
+    .download-email-modal .mktoFormCol, .download-email-modal .mktoFieldWrap {width:100%;}
+    .download-email-modal input {width:250px !important; padding:5px !important; margin-bottom:10px !important;}
+    .download-email-modal .mktoButtonWrap {margin-left:135px !important;}
+    .download-email-modal button[type="submit"] {background-image:none !important; background-color:#0166AE !important; border-radius:4px !important; border-color:#2e6da4 !important;}
+</style>
+
+<div class="modal fade download-email-modal" id="download-email-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
             <div class="modal-header">
@@ -7,8 +17,83 @@
             </div>
             <div class="modal-body">
                 <form id="mktoForm_2997"></form>
-                <p class="text-center" style="margin-top:10px;"><a href="{{ include.url | replace: '__VERSION__', site.flywayVersion }}">Skip to download</a></p>
+                <p class="text-center" style="margin-top:10px;"><a class="skip-to-download" href="">Skip to download</a></p>
             </div>
         </div>
     </div>
 </div>
+
+<script src="//content.red-gate.com/js/forms2/js/forms2.min.js"></script>
+<script>
+    MktoForms2.loadForm("//content.red-gate.com", "808-ITG-788", 2997, function(marketoForm) {
+        marketoForm.onValidate(function(successful) {
+            if (!successful) {
+                marketoForm.submittable(false);
+            } else {
+
+                // Do some custom validation.
+
+                // Get the fields and their values from the form.
+                var fields = marketoForm.vals();
+
+                // Custom object for storing info about the fail.
+                var fail = {
+                    isFail: false,
+                    message: '',
+                    element: null,
+                };
+
+                // Email validation.
+                if (typeof fields.Email !== 'undefined') {
+
+                    // Email regex provided by https://regex101.com/r/L9Z2N0/1.
+                    // Check that the format is {something}@{something}.{something}.
+                    var emailRegex = /\S+@\S+\.\S+/;
+
+                    if (emailRegex.test(fields.Email) === false) {
+                        fail.isFail = true;
+                        fail.message = 'Please enter a valid email address.';
+                        fail.element = marketoForm.getFormElem().find('input[name="Email"]');
+                    }
+                }
+
+                // If form validation fails.
+                if (fail.isFail) {
+
+                    // Stop the form from being submittable.
+                    marketoForm.submittable(false);
+
+                    // Show an error message against the invalid field.
+                    marketoForm.showErrorMessage(fail.message, fail.element);
+
+                    // Display the field as invalid using the Marketo class.
+                    fail.element.get(0).classList.add('mktoInvalid');
+                } else {
+
+                    // All is good, continue as normal.
+                    marketoForm.submittable(true);
+                }
+            }
+        });
+
+        // On successful submission of the form, redirect the user to the relevant download page.
+        marketoForm.onSuccess(function() {
+            var downloadLink = document.querySelector('.download-email-modal .skip-to-download');
+
+            if (downloadLink) {
+                
+                // Redirect the user to the download page.
+                window.location.href = downloadLink;
+
+                // Return false to stop the form from reloading the page.
+                return false;
+            }
+        });
+    });
+
+    function updateModalVersion (e) {
+        var downloadUrl = e.target.getAttribute('data-download-url');
+        var downloadLink = document.querySelector('.download-email-modal .skip-to-download');
+        downloadLink.href = downloadUrl;
+    }
+</script>

--- a/_includes/downloadpopup.html
+++ b/_includes/downloadpopup.html
@@ -1,0 +1,14 @@
+<div class="modal fade" id="download-email-modal-{{ include.id }}" tabindex="-1" role="dialog">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title" id="myModalLabel">Download</h4>
+            </div>
+            <div class="modal-body">
+                <form id="mktoForm_2997"></form>
+                <p class="text-center" style="margin-top:10px;"><a href="{{ include.url | replace: '__VERSION__', site.flywayVersion }}">Skip to download</a></p>
+            </div>
+        </div>
+    </div>
+</div>

--- a/_includes/downloadpopup.html
+++ b/_includes/downloadpopup.html
@@ -1,11 +1,12 @@
 <style>
-    .download-email-modal form {font-size:14px !important; width:auto !important;}
+    .download-email-modal form {font-size:14px !important; width:auto !important; margin:10px 20px;}
     .download-email-modal label {width:125px !important;}
     .download-email-modal .mktoOffset {display: none;}
     .download-email-modal .mktoFormCol, .download-email-modal .mktoFieldWrap {width:100%;}
     .download-email-modal input {width:250px !important; padding:5px !important; margin-bottom:10px !important;}
     .download-email-modal .mktoButtonWrap {margin-left:135px !important;}
     .download-email-modal button[type="submit"] {background-image:none !important; background-color:#0166AE !important; border-radius:4px !important; border-color:#2e6da4 !important;}
+    .download-email-modal .privacy-notice {background-color:#eee; padding:20px; border-radius:10px; margin:20px; font-size:13px;}
 </style>
 
 <div class="modal fade download-email-modal" id="download-email-modal" tabindex="-1" role="dialog">
@@ -17,6 +18,13 @@
             </div>
             <div class="modal-body">
                 <form id="mktoForm_2997"></form>
+
+                <div class="privacy-notice">
+                    <p>We'll use your details to follow up with you about our products, solutions and events.</p>
+                    <p>To stop hearing from us, use the unsubscribe links in our emails, or let us know.</p>
+                    <p><a href="https://www.red-gate.com/website/legal" target="_blank" rel="noopener noreferrer">Read the full privacy notice.</a></p>
+                </div>
+
                 <p class="text-center" style="margin-top:10px;"><a class="skip-to-download" href="">Skip to download</a></p>
             </div>
         </div>

--- a/documentation/commandline/index.md
+++ b/documentation/commandline/index.md
@@ -394,3 +394,61 @@ Add `-outputFile=/my/output.txt` to the argument list to also write output to th
     <a class="btn btn-primary" href="/documentation/commandline/migrate">Command-line: migrate <i
             class="fa fa-arrow-right"></i></a>
 </p>
+
+{% include downloadpopup.html name="Windows" id="windows" url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/__VERSION__/flyway-commandline-__VERSION__-windows-x64.zip" %}
+{% include downloadpopup.html name="Mac OSX" id="macosx" url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/__VERSION__/flyway-commandline-__VERSION__-macosx-x64.tar.gz" %}
+{% include downloadpopup.html name="Linux" id="linux" url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/__VERSION__/flyway-commandline-__VERSION__-linux-x64.tar.gz" %}
+
+<script src="//content.red-gate.com/js/forms2/js/forms2.min.js"></script>
+<script>MktoForms2.loadForm("//content.red-gate.com", "808-ITG-788", 2997, function(marketoForm) {
+
+    marketoForm.onValidate(function(successful) {
+        if (!successful) {
+            marketoForm.submittable(false);
+        } else {
+
+            // Do some custom validation.
+
+            // Get the fields and their values from the form.
+            var fields = marketoForm.vals();
+
+            // Custom object for storing info about the fail.
+            var fail = {
+                isFail: false,
+                message: '',
+                element: null,
+            };
+
+            // Email validation.
+            if (typeof fields.Email !== 'undefined') {
+
+                // Email regex provided by https://regex101.com/r/L9Z2N0/1.
+                // Check that the format is {something}@{something}.{something}.
+                var emailRegex = /\S+@\S+\.\S+/;
+
+                if (emailRegex.test(fields.Email) === false) {
+                    fail.isFail = true;
+                    fail.message = 'Please enter a valid email address.';
+                    fail.element = marketoForm.getFormElem().find('input[name="Email"]');
+                }
+            }
+
+            // If form validation fails.
+            if (fail.isFail) {
+
+                // Stop the form from being submittable.
+                marketoForm.submittable(false);
+
+                // Show an error message against the invalid field.
+                marketoForm.showErrorMessage(fail.message, fail.element);
+
+                // Display the field as invalid using the Marketo class.
+                fail.element.get(0).classList.add('mktoInvalid');
+            } else {
+
+                // All is good, continue as normal.
+                marketoForm.submittable(true);
+            }
+        }
+    });
+});</script>

--- a/documentation/commandline/index.md
+++ b/documentation/commandline/index.md
@@ -15,7 +15,7 @@ Select the platform that you need. Each download contains all editions (communit
 
 #### <i class="fa fa-windows"></i> Windows
 
-<a class="btn btn-primary btn-download" href="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-windows-x64.zip">flyway-commandline-{{site.flywayVersion}}-windows-x64.zip</a>
+<button class="btn btn-primary btn-download" data-toggle="modal" data-target="#download-email-modal-windows">flyway-commandline-{{site.flywayVersion}}-windows-x64.zip</button>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-windows-x64.zip.md5">md5</a>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-windows-x64.zip.sha1">sha1</a><br/>
 
@@ -23,7 +23,7 @@ Select the platform that you need. Each download contains all editions (communit
 
 #### <i class="fa fa-apple"></i> macOS
 
-<a class="btn btn-primary btn-download" href="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz">flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz</a>
+<button class="btn btn-primary btn-download" data-toggle="modal" data-target="#download-email-modal-macosx">flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz</button>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz.md5">md5</a>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz.sha1">sha1</a><br/><br/>
 
@@ -34,7 +34,7 @@ Download, extract and install by adding to `PATH` (requires `sudo` permissions):
 
 Or simply download the archive:
  
-<a class="btn btn-primary btn-download" href="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz">flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz</a>
+<button class="btn btn-primary btn-download" data-toggle="modal" data-target="#download-email-modal-linux">flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz</button>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz.md5">md5</a>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz.sha1">sha1</a><br/><br/>
 

--- a/documentation/commandline/index.md
+++ b/documentation/commandline/index.md
@@ -398,7 +398,6 @@ Add `-outputFile=/my/output.txt` to the argument list to also write output to th
 {% include downloadpopup.html %}
 <script>
     if (typeof updateModalVersion !== 'undefined') {   
-        window.console.log('Function exists!');
         var downloadButtons = document.querySelectorAll('.download-modal-button');
         for (var i=0; i<downloadButtons.length; i++) {
             downloadButtons[i].addEventListener('click', updateModalVersion);

--- a/documentation/commandline/index.md
+++ b/documentation/commandline/index.md
@@ -15,7 +15,7 @@ Select the platform that you need. Each download contains all editions (communit
 
 #### <i class="fa fa-windows"></i> Windows
 
-<button class="btn btn-primary btn-download" data-toggle="modal" data-target="#download-email-modal-windows">flyway-commandline-{{site.flywayVersion}}-windows-x64.zip</button>
+<button class="btn btn-primary btn-download download-modal-button" data-toggle="modal" data-target="#download-email-modal" data-download-url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-windows-x64.zip">flyway-commandline-{{site.flywayVersion}}-windows-x64.zip</button>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-windows-x64.zip.md5">md5</a>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-windows-x64.zip.sha1">sha1</a><br/>
 
@@ -23,7 +23,7 @@ Select the platform that you need. Each download contains all editions (communit
 
 #### <i class="fa fa-apple"></i> macOS
 
-<button class="btn btn-primary btn-download" data-toggle="modal" data-target="#download-email-modal-macosx">flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz</button>
+<button class="btn btn-primary btn-download download-modal-button" data-toggle="modal" data-target="#download-email-modal" data-download-url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz">flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz</button>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz.md5">md5</a>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-macosx-x64.tar.gz.sha1">sha1</a><br/><br/>
 
@@ -34,7 +34,7 @@ Download, extract and install by adding to `PATH` (requires `sudo` permissions):
 
 Or simply download the archive:
  
-<button class="btn btn-primary btn-download" data-toggle="modal" data-target="#download-email-modal-linux">flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz</button>
+<button class="btn btn-primary btn-download download-modal-button" data-toggle="modal" data-target="#download-email-modal" data-download-url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz">flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz</button>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz.md5">md5</a>
 <a class="note" href="https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{site.flywayVersion}}/flyway-commandline-{{site.flywayVersion}}-linux-x64.tar.gz.sha1">sha1</a><br/><br/>
 
@@ -395,60 +395,13 @@ Add `-outputFile=/my/output.txt` to the argument list to also write output to th
             class="fa fa-arrow-right"></i></a>
 </p>
 
-{% include downloadpopup.html name="Windows" id="windows" url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/__VERSION__/flyway-commandline-__VERSION__-windows-x64.zip" %}
-{% include downloadpopup.html name="Mac OSX" id="macosx" url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/__VERSION__/flyway-commandline-__VERSION__-macosx-x64.tar.gz" %}
-{% include downloadpopup.html name="Linux" id="linux" url="/download/thankyou?dl=https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/__VERSION__/flyway-commandline-__VERSION__-linux-x64.tar.gz" %}
-
-<script src="//content.red-gate.com/js/forms2/js/forms2.min.js"></script>
-<script>MktoForms2.loadForm("//content.red-gate.com", "808-ITG-788", 2997, function(marketoForm) {
-
-    marketoForm.onValidate(function(successful) {
-        if (!successful) {
-            marketoForm.submittable(false);
-        } else {
-
-            // Do some custom validation.
-
-            // Get the fields and their values from the form.
-            var fields = marketoForm.vals();
-
-            // Custom object for storing info about the fail.
-            var fail = {
-                isFail: false,
-                message: '',
-                element: null,
-            };
-
-            // Email validation.
-            if (typeof fields.Email !== 'undefined') {
-
-                // Email regex provided by https://regex101.com/r/L9Z2N0/1.
-                // Check that the format is {something}@{something}.{something}.
-                var emailRegex = /\S+@\S+\.\S+/;
-
-                if (emailRegex.test(fields.Email) === false) {
-                    fail.isFail = true;
-                    fail.message = 'Please enter a valid email address.';
-                    fail.element = marketoForm.getFormElem().find('input[name="Email"]');
-                }
-            }
-
-            // If form validation fails.
-            if (fail.isFail) {
-
-                // Stop the form from being submittable.
-                marketoForm.submittable(false);
-
-                // Show an error message against the invalid field.
-                marketoForm.showErrorMessage(fail.message, fail.element);
-
-                // Display the field as invalid using the Marketo class.
-                fail.element.get(0).classList.add('mktoInvalid');
-            } else {
-
-                // All is good, continue as normal.
-                marketoForm.submittable(true);
-            }
+{% include downloadpopup.html %}
+<script>
+    if (typeof updateModalVersion !== 'undefined') {   
+        window.console.log('Function exists!');
+        var downloadButtons = document.querySelectorAll('.download-modal-button');
+        for (var i=0; i<downloadButtons.length; i++) {
+            downloadButtons[i].addEventListener('click', updateModalVersion);
         }
-    });
-});</script>
+    }
+</script>


### PR DESCRIPTION
This PR adds a modal dialog when the download button is clicked, which includes a Marketo form asking for the users email address and name.

Once submitted the user is redirected to the download page for the selected version (Windows, Mac or Linux), as normal.

The modal dialog also includes a 'skip link', which provides the user with an option to skip the form and just go straight to the download page.