### PR TITLE
Add documentation for Azure Synapse

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -87,6 +87,9 @@ title: Documentation
                     {% if page.menu == 'sqlServer' %} class="active" {% endif %}>
                     <a href="/documentation/database/sqlserver">SQL Server</a></li>
                     <li
+                    {% if page.menu == 'azuresynapse' %} class="active" {% endif %}>
+                    <a href="/documentation/database/azuresynapse">Azure Synapse</a></li>
+                    <li
                     {% if page.menu == 'db2' %} class="active" {% endif %}>
                     <a href="/documentation/database/db2">DB2</a></li>
                     <li

--- a/about/index.html
+++ b/about/index.html
@@ -46,7 +46,8 @@ title: About Flyway
 
     <p>Supported databases are
         <a href="/documentation/database/oracle">Oracle</a>,
-        <a href="/documentation/database/sqlserver">SQL Server (including Amazon RDS and Azure SQL Database</a>,
+        <a href="/documentation/database/sqlserver">SQL Server (including Amazon RDS and Azure SQL Database)</a>,
+        <a href="/documentation/database/azuresynapse">Azure Synapse (Formerly Data Warehouse)</a>,
         <a href="/documentation/database/db2">DB2</a>,
         <a href="/documentation/database/mysql">MySQL</a> (including Amazon RDS, Azure Database &amp; Google Cloud SQL),
         <a href="/documentation/database/mariadb">MariaDB</a>,

--- a/documentation/database/azuresynapse.md
+++ b/documentation/database/azuresynapse.md
@@ -1,0 +1,74 @@
+---
+layout: documentation
+menu: azuresynapse
+subtitle: Azure Synapse
+---
+# Azure Synapse
+
+## Supported Versions
+
+- `Latest` {% include enterprise.html %}
+
+## Driver
+<table class="table">
+<tr>
+<th>URL format</th>
+<td><code>jdbc:sqlserver://<i>host</i>:<i>port</i>;databaseName=<i>database</i></code></td>
+</tr>
+<tr>
+<th>SSL support</th>
+<td><a href="https://docs.microsoft.com/en-us/sql/connect/jdbc/connecting-with-ssl-encryption?view=sql-server-ver15">Yes</a> - add <code>;encrypt=true</code></td>
+</tr>
+<tr>
+<th>Ships with Flyway Command-line</th>
+<td>Yes</td>
+</tr>
+<tr>
+<th>Maven Central coordinates</th>
+<td><code>com.microsoft.sqlserver:mssql-jdbc:7.2.0.jre8</code></td>
+</tr>
+<tr>
+<th>Supported versions</th>
+<td><code>4.0</code> and later</td>
+</tr>
+<tr>
+<th>Default Java class</th>
+<td><code>com.microsoft.sqlserver.jdbc.SQLServerDriver</code></td>
+</tr>
+</table>
+
+## Azure Synapse Syntax
+
+- [See SQL Server](/documentation/database/sqlserver#sql-server-syntax)
+
+### Compatibility
+
+- [See SQL Server](/documentation/database/sqlserver#compatibility)
+
+### Example
+
+```sql
+/* Single line comment */
+CREATE TABLE test_user (
+  id INT NOT NULL,
+  name VARCHAR(25) NOT NULL,  -- this is a valid ' comment
+  PRIMARY KEY NONCLUSTERED (name) NOT ENFORCED
+);
+GO
+
+-- Placeholder
+INSERT INTO ${tableName} (name) VALUES ('Mr. T');
+```
+
+## Authentication
+
+[See SQL Server](/documentation/database/sqlserver#authentication)
+
+## Limitations
+
+- [See SQL Server](/documentation/database/sqlserver#limitations)
+- The JTDS driver does not support Azure Synapse
+
+<p class="next-steps">
+    <a class="btn btn-primary" href="/documentation/database/db2">DB2 <i class="fa fa-arrow-right"></i></a>
+</p>

--- a/documentation/database/sqlserver.md
+++ b/documentation/database/sqlserver.md
@@ -192,5 +192,5 @@ consequences.
 a driver limitation, and can be solved by using the Microsoft driver instead.
 
 <p class="next-steps">
-    <a class="btn btn-primary" href="/documentation/database/db2">DB2 <i class="fa fa-arrow-right"></i></a>
+    <a class="btn btn-primary" href="/documentation/database/azuresynapse">Azure Synapse <i class="fa fa-arrow-right"></i></a>
 </p>

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -49,6 +49,7 @@ title: Documentation
 <p>Supported databases are
     <a href="/documentation/database/oracle">Oracle</a>,
     <a href="/documentation/database/sqlserver">SQL Server (including Amazon RDS and Azure SQL Database)</a>,
+    <a href="/documentation/database/azuresynapse">Azure Synapse (Formerly Data Warehouse)</a>,
     <a href="/documentation/database/db2">DB2</a>,
     <a href="/documentation/database/mysql">MySQL</a> (including Amazon RDS, Azure Database &amp; Google Cloud SQL),
     <a href="/documentation/database/aurora-mysql">Aurora MySQL</a>,

--- a/index.html
+++ b/index.html
@@ -205,6 +205,11 @@ hideNewsletterFooterForm: true
             <p>(incl. Amazon RDS &amp; Azure SQL Database)</p>
         </div>
         <div class="col-md-2">
+            <div class="marketing-item"><i class="fa fa-database"></i> <a href="/documentation/database/azuresynapse">Azure Synapse</a></div>
+
+            <p>(Formerly Data Warehouse)</p>
+        </div>
+        <div class="col-md-2">
             <div class="marketing-item"><i class="fa fa-database"></i> <a
                     href="/documentation/database/postgresql">PostgreSQL</a></div>
 


### PR DESCRIPTION
What do people think about having a separate page for Azure Synapse (as done in this PR), or should it be integrated into the documentation for SQL Server?