### PR TITLE
Document outputType on commandline

### DIFF
--- a/_posts/2019-11-26-flyway-6.1.0.md
+++ b/_posts/2019-11-26-flyway-6.1.0.md
@@ -39,7 +39,7 @@ Find out more [here](/documentation/database/snowflake)!
 
 ## Machine-readable output
 
-You can now output JSON from `flyway info` by using the `-json` flag (note: superseded by `-outputType=json` in Flyway 7).
+You can now output JSON from `flyway info` by using the `-json` flag.
 
 ```bash
 flyway info -json

--- a/_posts/2019-11-26-flyway-6.1.0.md
+++ b/_posts/2019-11-26-flyway-6.1.0.md
@@ -39,7 +39,7 @@ Find out more [here](/documentation/database/snowflake)!
 
 ## Machine-readable output
 
-You can now output JSON from `flyway info` by using the `-json` flag.
+You can now output JSON from `flyway info` by using the `-json` flag (note: superseded by `-output=json` in Flyway 7).
 
 ```bash
 flyway info -json

--- a/_posts/2019-11-26-flyway-6.1.0.md
+++ b/_posts/2019-11-26-flyway-6.1.0.md
@@ -39,7 +39,7 @@ Find out more [here](/documentation/database/snowflake)!
 
 ## Machine-readable output
 
-You can now output JSON from `flyway info` by using the `-json` flag (note: superseded by `-output=json` in Flyway 7).
+You can now output JSON from `flyway info` by using the `-json` flag (note: superseded by `-outputType=json` in Flyway 7).
 
 ```bash
 flyway info -json

--- a/documentation/commandline/index.md
+++ b/documentation/commandline/index.md
@@ -387,7 +387,7 @@ Add `-q` to the argument list to suppress all output, except for errors and warn
 
 ### Machine-readable output
 
-Add `-output=json` to the argument list to print JSON instead of human-readable output. Errors are included in the JSON payload instead of being sent to `stderr`.
+Add `-outputType=json` to the argument list to print JSON instead of human-readable output. Errors are included in the JSON payload instead of being sent to `stderr`.
 
 ### Writing to a file
 

--- a/documentation/commandline/index.md
+++ b/documentation/commandline/index.md
@@ -385,9 +385,9 @@ with normal command-line tools, for example:
 
 Add `-q` to the argument list to suppress all output, except for errors and warnings.
 
-### JSON
+### Machine-readable output
 
-Add `-json` to the argument list to print JSON instead of human-readable output. Errors are included in the JSON payload instead of being sent to `stderr`.
+Add `-output=json` to the argument list to print JSON instead of human-readable output. Errors are included in the JSON payload instead of being sent to `stderr`.
 
 ### Writing to a file
 

--- a/documentation/releaseNotes.html
+++ b/documentation/releaseNotes.html
@@ -36,7 +36,7 @@ subtitle: Release Notes
         {% include issue.html id="2808" title="Placeholder names are now case insensitive" %}
         {% include issue.html id="2805" title="The CLI default flyway.conf now specifies the location filesystem:sql" %}
         {% include issue.html id="" title="Non existent locations now display an error in the output" %}
-        {% include issue.html id="" title="Command-line option `-json` superseded by `-output=json`" %}
+        {% include issue.html id="" title="Command-line option `-json` superseded by `-outputType=json`" %}
     </ul>
 
     <h3>Breaking changes</h3>

--- a/documentation/releaseNotes.html
+++ b/documentation/releaseNotes.html
@@ -36,6 +36,7 @@ subtitle: Release Notes
         {% include issue.html id="2808" title="Placeholder names are now case insensitive" %}
         {% include issue.html id="2805" title="The CLI default flyway.conf now specifies the location filesystem:sql" %}
         {% include issue.html id="" title="Non existent locations now display an error in the output" %}
+        {% include issue.html id="" title="Command-line option `-json` superseded by `-output=json`" %}
     </ul>
 
     <h3>Breaking changes</h3>


### PR DESCRIPTION
In v7, `outputType=json` becomes preferred to `-json` (the latter will continue to work until v8)