### PR TITLE
Remove duplicate command argument in documentation for repair

### DIFF
--- a/documentation/commandline/repair.md
+++ b/documentation/commandline/repair.md
@@ -116,7 +116,6 @@ Repairs the Flyway schema history table. This will perform the following actions
             Multiple suffixes (like .sql,.pkg,.pkb) can be specified for easier compatibility with other tools such as
             editors with specific file associations.</td>
     </tr>
-     {% include cfg/validateMigrationNaming.html %}
     <tr>
         <td>encoding</td>
         <td>NO</td>


### PR DESCRIPTION
The documentation page for the `repair` command lists the `validateMigrationNaming` argument twice. This removes one of the mentions.