### PR TITLE
Upgrading to teams

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -155,6 +155,9 @@ title: Documentation
                     <a href="/documentation/database/firebird">Firebird</a></li>
                     <li class="nav-header">Learn more</li>
                     <li
+                    {% if page.menu == 'upgradingToTeams' %} class="active" {% endif %}>
+                    <a href="/documentation/upgradingToTeams">Upgrading to Flyway Teams</a></li>
+                    <li
                     {% if page.menu == 'existing' %} class="active" {% endif %}>
                     <a href="/documentation/existing">Existing database setup</a></li>
                     <li

--- a/documentation/configuration/edition.md
+++ b/documentation/configuration/edition.md
@@ -27,10 +27,10 @@ FLYWAY_EDITION=teams
 ```
 
 ### API
-Not available
+See [upgrading api to Teams](/documentation/upgradingToTeams#api)
 
 ### Gradle
-Not available
+See [upgrading gradle to Teams](/documentation/upgradingToTeams#gradle)
 
 ### Maven
-Not available
+See [upgrading maven to Teams](/documentation/upgradingToTeams#maven)

--- a/documentation/configuration/licenseKey.md
+++ b/documentation/configuration/licenseKey.md
@@ -5,45 +5,47 @@ pill: licenseKey
 subtitle: flyway.licenseKey
 ---
 
-# Oracle SQL*Plus Warn
+# License Key
 {% include teams.html %}
 
 ## Description
-Your Flyway license key (FL01...). Not yet a Flyway Teams Edition customer? Request your <a href="" data-toggle="modal" data-target="#flyway-trial-license-modal">Flyway trial license key</a> to try out Flyway Teams Edition features free for 30 days.
+Your Flyway license key (`FL01...`) when using Flyway Teams. This should be 516 alpha numeric characters, beginning with `FL`.
+
+Not yet a Flyway Teams Edition customer? Request your <a href="" data-toggle="modal" data-target="#flyway-trial-license-modal">Flyway trial license key</a> to try out Flyway Teams Edition features free for 30 days.
 
 ## Usage
 
 ### Commandline
-```
+```powershell
 ./flyway -licenseKey="FL01..." info
 ```
 
 ### Configuration File
-```
+```properties
 flyway.licenseKey=FL01...
 ```
 
 ### Environment Variable
-```
+```properties
 FLYWAY_LICENSE_KEY=FL01...
 ```
 
 ### API
-```
+```java
 Flyway.configure()
     .licenseKey("FL01...")
     .load()
 ```
 
 ### Gradle
-```
+```groovy
 flyway {
     licenseKey = 'FL01...'
 }
 ```
 
 ### Maven
-```
+```xml
 <configuration>
     <licenseKey>FL01...</licenseKey>
 </configuration>

--- a/documentation/upgradingToTeams.md
+++ b/documentation/upgradingToTeams.md
@@ -10,12 +10,13 @@ This article assumes you are a proud owner of a Flyway Teams license. If you are
 
 ## Upgrading from community
 
-If you are currently using Flyway Community there are a few things you need to do to upgrade to using Flyway Teams. The steps to do so differ depending on how you are accessing Flyway, but broadly consist of two main steps. Telling Flyway to use the [correct edition](/documentation/configuration/edition), and supplying a [license key](/documentation/configuration/licenseKey). See below for more details for each usage.
+If you are currently using Flyway Community there are a few things you need to do to upgrade to using Flyway Teams. The process to do so differs depending on how you are accessing Flyway, but broadly consists of telling Flyway to use the [correct edition](/documentation/configuration/edition), and supplying a [license key](/documentation/configuration/licenseKey). See below for more details for each usage.
 
 ### Command Line
 
 If you are using the command line, simply add the `-teams` flag when you invoke Flyway (or use the environment variable `FLYWAY_EDITION=teams`). Then provide your [license key](/documentation/configuration/licenseKey) through any of the supported methods.
 
+For example:
 ```powershell
 ./flyway -teams -licenseKey=FL01... info
 ```
@@ -24,6 +25,7 @@ If you are using the command line, simply add the `-teams` flag when you invoke 
 
 If you are using the API, simply swap your dependency from `org.flywaydb.flyway` to `org.flywaydb.flyway.enterprise`. Then provide your [license key](/documentation/configuration/licenseKey) through any of the supported methods.
 
+For example:
 ```groovy
 // gradle
 dependencies {
@@ -41,6 +43,7 @@ flyway.info();
 
 If you are using the Gradle plugin, swap the plugin dependency from `id "org.flywaydb.flyway" version "{{ site.flywayVersion }}"` to `id "org.flywaydb.flyway.enterprise" version "{{ site.flywayVersion }}"`. Then provide your [license key](/documentation/configuration/licenseKey) through any of the supported methods.
 
+For example:
 ```groovy
 plugins {
     id "org.flywaydb.flyway.enterprise" version "{{ site.flywayVersion }}"
@@ -55,6 +58,7 @@ flyway {
 
 If you are using the Maven plugin, swap the plugin dependency from `<groupId>org.flywaydb</groupId>` to `<groupId>org.flywaydb.enterprise</groupId>`. Then provide your [license key](/documentation/configuration/licenseKey) through any of the supported methods.
 
+For example:
 ```xml
 <plugin>
     <groupId>org.flywaydb.enterprise</groupId>

--- a/documentation/upgradingToTeams.md
+++ b/documentation/upgradingToTeams.md
@@ -1,0 +1,85 @@
+---
+layout: documentation
+menu: upgradingToTeams
+subtitle: Upgrading to Teams
+---
+
+# Upgrading to Teams
+
+This article assumes you are a proud owner of a Flyway Teams license. If you are not, head over to the [download/pricing page](/download) to purchase a license or start a free trial.
+
+## Upgrading from community
+
+If you are currently using Flyway Community there are a few things you need to do to upgrade to using Flyway Teams. The steps to do so differ depending on how you are accessing Flyway, but broadly consist of two main steps. Telling Flyway to use the [correct edition](/documentation/configuration/edition), and supplying a [license key](/documentation/configuration/licenseKey). See below for more details for each usage.
+
+### Command Line
+
+If you are using the command line, simply add the `-teams` flag when you invoke Flyway (or use the environment variable `FLYWAY_EDITION=teams`). Then provide your [license key](/documentation/configuration/licenseKey) through any of the supported methods.
+
+```powershell
+./flyway -teams -licenseKey=FL01... info
+```
+
+### API
+
+If you are using the API, simply swap your dependency from `org.flywaydb.flyway` to `org.flywaydb.flyway.enterprise`. Then provide your [license key](/documentation/configuration/licenseKey) through any of the supported methods.
+
+```groovy
+// gradle
+dependencies {
+    compile 'org.flywaydb.enterprise:flyway-core:{{ site.flywayVersion }}'
+}
+
+// code
+Flyway flyway = Flyway.configure()
+    .licenseKey("FL01...")
+    .load();
+flyway.info();
+```
+
+### Gradle
+
+If you are using the Gradle plugin, swap the plugin dependency from `id "org.flywaydb.flyway" version "{{ site.flywayVersion }}"` to `id "org.flywaydb.flyway.enterprise" version "{{ site.flywayVersion }}"`. Then provide your [license key](/documentation/configuration/licenseKey) through any of the supported methods.
+
+```groovy
+plugins {
+    id "org.flywaydb.flyway.enterprise" version "{{ site.flywayVersion }}"
+}
+
+flyway {
+    licenseKey = 'FL01...'
+}
+```
+
+### Maven
+
+If you are using the Maven plugin, swap the plugin dependency from `<groupId>org.flywaydb</groupId>` to `<groupId>org.flywaydb.enterprise</groupId>`. Then provide your [license key](/documentation/configuration/licenseKey) through any of the supported methods.
+
+```xml
+<plugin>
+    <groupId>org.flywaydb.enterprise</groupId>
+    <artifactId>flyway-maven-plugin</artifactId>
+    <version>7.0.0</version>
+
+    <configuration>
+        <licenseKey>FL01...</licenseKey>
+    </configuration>
+</plugin>
+```
+
+## New Features
+
+Now that you are using the Teams edition of Flyway, you can take advantage of all the powerful new features at your disposal:
+
+- Begin creating [Undo migrations](/documentation/migrations#undo-migrations) to allow rollback of deployments.
+- Begin storing your migrations in cloud storage such as [Amazon S3](/documentation/configuration/locations#amazon-s3) or [Google Cloud Storage](/documentation/configuration/locations#google-cloud-storage).
+- Begin writing migrations in languages other than SQL and Java using [script migrations](/documentation/migrations#script-migrations).
+- Preview your deployments, or execute them outside of Flyway using [Dry Runs](/documentation/dryruns).
+- Optimise the execution of migrations using [batching](/documentation/configuration/batch) or [streaming](/documentation/configuration/stream).
+- Gain more control over your deployments by [cherry picking](/documentation/configuration/cherryPick) which migrations to execute.
+- Apply migrations manually outside of Flyway but update the schema history using [mark as applied](/documentation/configuration/skipExecutingMigrations).
+- [Guaranteed support for databases](/download/faq#how-long-are-database-releases-supported-in-each-edition-of-flyway) up to 10 years old.
+- Leverage the power of [Oracle SQL*Plus](/documentation/database/oracle#sqlplus-commands) in your migrations.
+- Promote database warnings to errors, or ignore errors thrown during execution with [error overrides](/documentation/erroroverrides).
+
+... and much more. See [parameters](/documentation/configuration/) for all the Teams configuration parameters.

--- a/download/faq.md
+++ b/download/faq.md
@@ -112,5 +112,9 @@ Flyway subscriptions can be purchased for one, two or three year terms giving yo
 
 We can arrange an invoice for your Flyway license for Teams tier. You can register for a Redgate Account on our website [www.red-gate.com](https://www.red-gate.com) to give you full visibility and management of your licenses.
 
+## I already own a license, how do I use it?
+
+See [upgrading to Teams](/documentation/upgradingToTeams) for step-by-step instructions on how to upgrade your Flyway community installation to Flyway Teams.
+
 
 {% include trialpopup.html %}

--- a/download/index.md
+++ b/download/index.md
@@ -35,8 +35,8 @@ Choose your Flyway edition based on the features and support level you require
 <tr><td>Statement-level callbacks</td><td></td><td><i class="fa fa-check"></i></td></tr>
 <tr><td><a href="/documentation/dryruns">Dry runs</a></td><td></td><td><i class="fa fa-check"></i></td></tr>
 <tr><td><a href="/documentation/command/undo">Undo</a></td><td></td><td><i class="fa fa-check"></i></td></tr>
-<tr><td>Batching</td><td></td><td><i class="fa fa-check"></i></td></tr>
-<tr><td>Streaming</td><td></td><td><i class="fa fa-check"></i></td></tr>
+<tr><td><a href="/documentation/configuration/batch">Batching</a></td><td></td><td><i class="fa fa-check"></i></td></tr>
+<tr><td><a href="/documentation/configuration/stream">Streaming</a></td><td></td><td><i class="fa fa-check"></i></td></tr>
 <tr><td><a href="/documentation/configuration/cherryPick">Cherry picking</a></td><td></td><td><i class="fa fa-check"></i></td></tr>
 <tr><td><a href="/documentation/configuration/skipExecutingMigrations">Mark as applied</a></td><td></td><td><i class="fa fa-check"></i></td></tr>
 <tr><td><a href="/documentation/migrations#query-results">Toggle display of query results</a></td><td></td><td><i class="fa fa-check"></i></td></tr>


### PR DESCRIPTION
Currently the page is only linked off the FAQ. Should we add a link to this somewhere in the trial modal? Or maybe put it into the email we send to people?