### PR TITLE
Add dropdowns for usage pages

### DIFF
--- a/_layouts/commandLine.html
+++ b/_layouts/commandLine.html
@@ -6,28 +6,28 @@ menu: commandLine
     <div id="pills">
     <ul class="nav nav-pills">
         <li
-        {% if page.pill == 'overview' %} class="active" {% endif %}>
+        {% if page.pill == 'cli_overview' %} class="active" {% endif %}>
         <a href="/documentation/usage/commandline">Overview</a></li>
         <li
-        {% if page.pill == 'migrate' %} class="active" {% endif %}>
+        {% if page.pill == 'cli_migrate' %} class="active" {% endif %}>
         <a href="/documentation/usage/commandline/migrate">migrate</a></li>
         <li
-        {% if page.pill == 'clean' %} class="active" {% endif %}>
+        {% if page.pill == 'cli_clean' %} class="active" {% endif %}>
         <a href="/documentation/usage/commandline/clean">clean</a></li>
         <li
-        {% if page.pill == 'info' %} class="active" {% endif %}>
+        {% if page.pill == 'cli_info' %} class="active" {% endif %}>
         <a href="/documentation/usage/commandline/info">info</a></li>
         <li
-        {% if page.pill == 'validate' %} class="active" {% endif %}>
+        {% if page.pill == 'cli_validate' %} class="active" {% endif %}>
         <a href="/documentation/usage/commandline/validate">validate</a></li>
         <li
-        {% if page.pill == 'undo' %} class="active" {% endif %}>
+        {% if page.pill == 'cli_undo' %} class="active" {% endif %}>
         <a href="/documentation/usage/commandline/undo">undo</a></li>
         <li
-        {% if page.pill == 'baseline' %} class="active" {% endif %}>
+        {% if page.pill == 'cli_baseline' %} class="active" {% endif %}>
         <a href="/documentation/usage/commandline/baseline">baseline</a></li>
         <li
-        {% if page.pill == 'repair' %} class="active" {% endif %}>
+        {% if page.pill == 'cli_repair' %} class="active" {% endif %}>
         <a href="/documentation/usage/commandline/repair">repair</a></li>
     </ul>
     </div>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -224,11 +224,41 @@ title: Documentation
                             </ul>
                         </details>
 
-                        <ul class="nav nav-pills nav-stacked">
-                            <li
-                            {% if layout.menu == 'gradle' %} class="active" {% endif %}>
-                            <a href="/documentation/usage/gradle">Gradle</a></li>
+                        <details {% if layout.menu == 'gradle' %} open {% endif %} class="collapsible-nested">
+                            <summary class="nav-header"><a href="/documentation/usage/gradle">Gradle</a></summary>
 
+                            <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.pill == 'migrate' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/gradle/migrate">migrate</a></li>
+
+                                <li
+                                {% if page.pill == 'clean' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/gradle/clean">clean</a></li>
+
+                                <li
+                                {% if page.pill == 'info' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/gradle/info">info</a></li>
+
+                                <li
+                                {% if page.pill == 'validate' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/gradle/validate">validate</a></li>
+
+                                <li
+                                {% if page.pill == 'undo' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/gradle/undo">undo</a></li>
+
+                                <li
+                                {% if page.pill == 'baseline' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/gradle/baseline">baseline</a></li>
+
+                                <li
+                                {% if page.pill == 'repair' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/gradle/repair">repair</a></li>
+                            </ul>
+                        </details>
+
+                        <ul class="nav nav-pills nav-stacked">
                             <li
                             {% if page.menu == 'plugins' %} class="active" {% endif %}>
                             <a href="/documentation/usage/plugins/">Community Plugins</a></li>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -143,9 +143,13 @@ title: Documentation
                         <summary class="nav-header">Usage</summary>
 
                         <details {% if layout.menu == 'commandLine' %} open {% endif %} class="collapsible-nested">
-                            <summary class="nav-header"><a href="/documentation/usage/commandline">Command-line</a></summary>
+                            <summary class="nav-header">Command-line</summary>
 
                             <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.pill == 'cli_overview' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/commandline">Overview</a></li>
+
                                 <li
                                 {% if page.pill == 'cli_migrate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/commandline/migrate">migrate</a></li>
@@ -177,9 +181,13 @@ title: Documentation
                         </details>
 
                         <details {% if layout.menu == 'api' %} open {% endif %} class="collapsible-nested">
-                            <summary class="nav-header"><a href="/documentation/usage/api">API (Java / Android)</a></summary>
+                            <summary class="nav-header">API (Java / Android)</summary>
 
                             <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.pill == 'overview' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/api">Overview</a></li>
+
                                 <li
                                 {% if page.pill == 'hooks' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/api/hooks">Hooks</a></li>
@@ -191,9 +199,13 @@ title: Documentation
                         </details>
 
                         <details {% if layout.menu == 'maven' %} open {% endif %} class="collapsible-nested">
-                            <summary class="nav-header"><a href="/documentation/usage/maven">Maven</a></summary>
+                            <summary class="nav-header">Maven</summary>
 
                             <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.pill == 'mvn_overview' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/maven">Overview</a></li>
+
                                 <li
                                 {% if page.pill == 'mvn_migrate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/maven/migrate">migrate</a></li>
@@ -225,9 +237,13 @@ title: Documentation
                         </details>
 
                         <details {% if layout.menu == 'gradle' %} open {% endif %} class="collapsible-nested">
-                            <summary class="nav-header"><a href="/documentation/usage/gradle">Gradle</a></summary>
+                            <summary class="nav-header">Gradle</summary>
 
                             <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.pill == 'gradle_overview' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/gradle">Overview</a></li>
+
                                 <li
                                 {% if page.pill == 'gradle_migrate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/gradle/migrate">migrate</a></li>
@@ -269,9 +285,13 @@ title: Documentation
                         <summary class="nav-header">Configuration</summary>
 
                         <details {% if page.url contains "documentation/configuration/parameters/" %} open {% endif %} class="collapsible-nested">
-                            <summary class="nav-header"><a href="/documentation/configuration/parameters">Parameters</a></summary>
+                            <summary class="nav-header">Parameters</summary>
 
                             <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.menu == 'configuration' %} class="active" {% endif %}>
+                                <a href="/documentation/configuration/parameters">Overview</a></li>
+
                                 <li
                                 {% if page.pill == 'baselineDescription' %} class="active" {% endif %}>
                                 <a href="/documentation/configuration/parameters/baselineDescription">baselineDescription</a></li>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -190,11 +190,41 @@ title: Documentation
                             </ul>
                         </details>
 
-                        <ul class="nav nav-pills nav-stacked">
-                            <li
-                            {% if layout.menu == 'maven' %} class="active" {% endif %}>
-                            <a href="/documentation/usage/maven">Maven</a></li>
+                        <details {% if layout.menu == 'maven' %} open {% endif %} class="collapsible-nested">
+                            <summary class="nav-header"><a href="/documentation/usage/maven">Maven</a></summary>
 
+                            <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.pill == 'migrate' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/maven/migrate">migrate</a></li>
+
+                                <li
+                                {% if page.pill == 'clean' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/maven/clean">clean</a></li>
+
+                                <li
+                                {% if page.pill == 'info' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/maven/info">info</a></li>
+
+                                <li
+                                {% if page.pill == 'validate' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/maven/validate">validate</a></li>
+
+                                <li
+                                {% if page.pill == 'undo' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/maven/undo">undo</a></li>
+
+                                <li
+                                {% if page.pill == 'baseline' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/maven/baseline">baseline</a></li>
+
+                                <li
+                                {% if page.pill == 'repair' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/maven/repair">repair</a></li>
+                            </ul>
+                        </details>
+
+                        <ul class="nav nav-pills nav-stacked">
                             <li
                             {% if layout.menu == 'gradle' %} class="active" {% endif %}>
                             <a href="/documentation/usage/gradle">Gradle</a></li>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -142,11 +142,41 @@ title: Documentation
                     <details {% if page.url contains "documentation/usage" %} open {% endif %}>
                         <summary class="nav-header">Usage</summary>
 
-                        <ul class="nav nav-pills nav-stacked">
-                            <li
-                            {% if layout.menu == 'commandLine' %} class="active" {% endif %}>
-                            <a href="/documentation/usage/commandline">Command-line</a></li>
+                        <details {% if layout.menu == 'commandLine' %} open {% endif %} class="collapsible-nested">
+                            <summary class="nav-header"><a href="/documentation/usage/commandline">Command-line</a></summary>
 
+                            <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.pill == 'migrate' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/commandline/migrate">migrate</a></li>
+
+                                <li
+                                {% if page.pill == 'clean' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/commandline/clean">clean</a></li>
+
+                                <li
+                                {% if page.pill == 'info' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/commandline/info">info</a></li>
+
+                                <li
+                                {% if page.pill == 'validate' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/commandline/validate">validate</a></li>
+
+                                <li
+                                {% if page.pill == 'undo' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/commandline/undo">undo</a></li>
+
+                                <li
+                                {% if page.pill == 'baseline' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/commandline/baseline">baseline</a></li>
+
+                                <li
+                                {% if page.pill == 'repair' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/commandline/repair">repair</a></li>
+                            </ul>
+                        </details>
+
+                        <ul class="nav nav-pills nav-stacked">
                             <li
                             {% if layout.menu == 'api' %} class="active" {% endif %}>
                             <a href="/documentation/usage/api">API (Java / Android)</a></li>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -176,11 +176,21 @@ title: Documentation
                             </ul>
                         </details>
 
-                        <ul class="nav nav-pills nav-stacked">
-                            <li
-                            {% if layout.menu == 'api' %} class="active" {% endif %}>
-                            <a href="/documentation/usage/api">API (Java / Android)</a></li>
+                        <details {% if layout.menu == 'api' %} open {% endif %} class="collapsible-nested">
+                            <summary class="nav-header"><a href="/documentation/usage/api">API (Java / Android)</a></summary>
 
+                            <ul class="nav nav-pills nav-stacked">
+                                <li
+                                {% if page.pill == 'hooks' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/api/hooks">Hooks</a></li>
+
+                                <li
+                                {% if page.pill == 'javadoc' %} class="active" {% endif %}>
+                                <a href="/documentation/usage/api/javadoc.html">Javadoc</a></li>
+                            </ul>
+                        </details>
+
+                        <ul class="nav nav-pills nav-stacked">
                             <li
                             {% if layout.menu == 'maven' %} class="active" {% endif %}>
                             <a href="/documentation/usage/maven">Maven</a></li>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -147,31 +147,31 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.pill == 'migrate' %} class="active" {% endif %}>
+                                {% if page.pill == 'cli_migrate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/commandline/migrate">migrate</a></li>
 
                                 <li
-                                {% if page.pill == 'clean' %} class="active" {% endif %}>
+                                {% if page.pill == 'cli_clean' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/commandline/clean">clean</a></li>
 
                                 <li
-                                {% if page.pill == 'info' %} class="active" {% endif %}>
+                                {% if page.pill == 'cli_info' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/commandline/info">info</a></li>
 
                                 <li
-                                {% if page.pill == 'validate' %} class="active" {% endif %}>
+                                {% if page.pill == 'cli_validate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/commandline/validate">validate</a></li>
 
                                 <li
-                                {% if page.pill == 'undo' %} class="active" {% endif %}>
+                                {% if page.pill == 'cli_undo' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/commandline/undo">undo</a></li>
 
                                 <li
-                                {% if page.pill == 'baseline' %} class="active" {% endif %}>
+                                {% if page.pill == 'cli_baseline' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/commandline/baseline">baseline</a></li>
 
                                 <li
-                                {% if page.pill == 'repair' %} class="active" {% endif %}>
+                                {% if page.pill == 'cli_repair' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/commandline/repair">repair</a></li>
                             </ul>
                         </details>
@@ -195,31 +195,31 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.pill == 'migrate' %} class="active" {% endif %}>
+                                {% if page.pill == 'mvn_migrate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/maven/migrate">migrate</a></li>
 
                                 <li
-                                {% if page.pill == 'clean' %} class="active" {% endif %}>
+                                {% if page.pill == 'mvn_clean' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/maven/clean">clean</a></li>
 
                                 <li
-                                {% if page.pill == 'info' %} class="active" {% endif %}>
+                                {% if page.pill == 'mvn_info' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/maven/info">info</a></li>
 
                                 <li
-                                {% if page.pill == 'validate' %} class="active" {% endif %}>
+                                {% if page.pill == 'mvn_validate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/maven/validate">validate</a></li>
 
                                 <li
-                                {% if page.pill == 'undo' %} class="active" {% endif %}>
+                                {% if page.pill == 'mvn_undo' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/maven/undo">undo</a></li>
 
                                 <li
-                                {% if page.pill == 'baseline' %} class="active" {% endif %}>
+                                {% if page.pill == 'mvn_baseline' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/maven/baseline">baseline</a></li>
 
                                 <li
-                                {% if page.pill == 'repair' %} class="active" {% endif %}>
+                                {% if page.pill == 'mvn_repair' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/maven/repair">repair</a></li>
                             </ul>
                         </details>
@@ -229,31 +229,31 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.pill == 'migrate' %} class="active" {% endif %}>
+                                {% if page.pill == 'gradle_migrate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/gradle/migrate">migrate</a></li>
 
                                 <li
-                                {% if page.pill == 'clean' %} class="active" {% endif %}>
+                                {% if page.pill == 'gradle_clean' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/gradle/clean">clean</a></li>
 
                                 <li
-                                {% if page.pill == 'info' %} class="active" {% endif %}>
+                                {% if page.pill == 'gradle_info' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/gradle/info">info</a></li>
 
                                 <li
-                                {% if page.pill == 'validate' %} class="active" {% endif %}>
+                                {% if page.pill == 'gradle_validate' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/gradle/validate">validate</a></li>
 
                                 <li
-                                {% if page.pill == 'undo' %} class="active" {% endif %}>
+                                {% if page.pill == 'gradle_undo' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/gradle/undo">undo</a></li>
 
                                 <li
-                                {% if page.pill == 'baseline' %} class="active" {% endif %}>
+                                {% if page.pill == 'gradle_baseline' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/gradle/baseline">baseline</a></li>
 
                                 <li
-                                {% if page.pill == 'repair' %} class="active" {% endif %}>
+                                {% if page.pill == 'gradle_repair' %} class="active" {% endif %}>
                                 <a href="/documentation/usage/gradle/repair">repair</a></li>
                             </ul>
                         </details>

--- a/_layouts/gradle.html
+++ b/_layouts/gradle.html
@@ -6,28 +6,28 @@ menu: gradle
     <div id="pills">
         <ul class="nav nav-pills">
         <li
-        {% if page.pill == 'overview' %} class="active" {% endif %}>
+        {% if page.pill == 'gradle_overview' %} class="active" {% endif %}>
         <a href="/documentation/usage/gradle">Overview</a></li>
         <li
-        {% if page.pill == 'migrate' %} class="active" {% endif %}>
+        {% if page.pill == 'gradle_migrate' %} class="active" {% endif %}>
         <a href="/documentation/usage/gradle/migrate">migrate</a></li>
         <li
-        {% if page.pill == 'clean' %} class="active" {% endif %}>
+        {% if page.pill == 'gradle_clean' %} class="active" {% endif %}>
         <a href="/documentation/usage/gradle/clean">clean</a></li>
         <li
-        {% if page.pill == 'info' %} class="active" {% endif %}>
+        {% if page.pill == 'gradle_info' %} class="active" {% endif %}>
         <a href="/documentation/usage/gradle/info">info</a></li>
         <li
-        {% if page.pill == 'validate' %} class="active" {% endif %}>
+        {% if page.pill == 'gradle_validate' %} class="active" {% endif %}>
         <a href="/documentation/usage/gradle/validate">validate</a></li>
         <li
-        {% if page.pill == 'undo' %} class="active" {% endif %}>
+        {% if page.pill == 'gradle_undo' %} class="active" {% endif %}>
         <a href="/documentation/usage/gradle/undo">undo</a></li>
         <li
-        {% if page.pill == 'baseline' %} class="active" {% endif %}>
+        {% if page.pill == 'gradle_baseline' %} class="active" {% endif %}>
         <a href="/documentation/usage/gradle/baseline">baseline</a></li>
         <li
-        {% if page.pill == 'repair' %} class="active" {% endif %}>
+        {% if page.pill == 'gradle_repair' %} class="active" {% endif %}>
         <a href="/documentation/usage/gradle/repair">repair</a></li>
     </ul>
         </div>

--- a/_layouts/maven.html
+++ b/_layouts/maven.html
@@ -6,28 +6,28 @@ menu: maven
     <div id="pills">
         <ul class="nav nav-pills">
         <li
-        {% if page.pill == 'overview' %} class="active" {% endif %}>
+        {% if page.pill == 'mvn_overview' %} class="active" {% endif %}>
         <a href="/documentation/usage/maven">Overview</a></li>
         <li
-        {% if page.pill == 'migrate' %} class="active" {% endif %}>
+        {% if page.pill == 'mvn_migrate' %} class="active" {% endif %}>
         <a href="/documentation/usage/maven/migrate">migrate</a></li>
         <li
-        {% if page.pill == 'clean' %} class="active" {% endif %}>
+        {% if page.pill == 'mvn_clean' %} class="active" {% endif %}>
         <a href="/documentation/usage/maven/clean">clean</a></li>
         <li
-        {% if page.pill == 'info' %} class="active" {% endif %}>
+        {% if page.pill == 'mvn_info' %} class="active" {% endif %}>
         <a href="/documentation/usage/maven/info">info</a></li>
         <li
-        {% if page.pill == 'validate' %} class="active" {% endif %}>
+        {% if page.pill == 'mvn_validate' %} class="active" {% endif %}>
         <a href="/documentation/usage/maven/validate">validate</a></li>
         <li
-        {% if page.pill == 'undo' %} class="active" {% endif %}>
+        {% if page.pill == 'mvn_undo' %} class="active" {% endif %}>
         <a href="/documentation/usage/maven/undo">undo</a></li>
         <li
-        {% if page.pill == 'baseline' %} class="active" {% endif %}>
+        {% if page.pill == 'mvn_baseline' %} class="active" {% endif %}>
         <a href="/documentation/usage/maven/baseline">baseline</a></li>
         <li
-        {% if page.pill == 'repair' %} class="active" {% endif %}>
+        {% if page.pill == 'mvn_repair' %} class="active" {% endif %}>
         <a href="/documentation/usage/maven/repair">repair</a></li>
     </ul>
         </div>

--- a/documentation/usage/commandline/baseline.md
+++ b/documentation/usage/commandline/baseline.md
@@ -1,6 +1,6 @@
 ---
 layout: commandLine
-pill: baseline
+pill: cli_baseline
 subtitle: 'Command-line: baseline'
 ---
 # Command-line: baseline

--- a/documentation/usage/commandline/clean.md
+++ b/documentation/usage/commandline/clean.md
@@ -1,6 +1,6 @@
 ---
 layout: commandLine
-pill: clean
+pill: cli_clean
 subtitle: 'Command-line: clean'
 ---
 # Command-line: clean

--- a/documentation/usage/commandline/index.md
+++ b/documentation/usage/commandline/index.md
@@ -1,6 +1,6 @@
 ---
 layout: commandLine
-pill: overview
+pill: cli_overview
 subtitle: Command-line
 redirect_from: /documentation/commandline
 ---

--- a/documentation/usage/commandline/info.md
+++ b/documentation/usage/commandline/info.md
@@ -1,6 +1,6 @@
 ---
 layout: commandLine
-pill: info
+pill: cli_info
 subtitle: 'Command-line: info'
 ---
 # Command-line: info

--- a/documentation/usage/commandline/migrate.md
+++ b/documentation/usage/commandline/migrate.md
@@ -1,6 +1,6 @@
 ---
 layout: commandLine
-pill: migrate
+pill: cli_migrate
 subtitle: 'Command-line: migrate'
 ---
 # Command-line: migrate

--- a/documentation/usage/commandline/repair.md
+++ b/documentation/usage/commandline/repair.md
@@ -1,6 +1,6 @@
 ---
 layout: commandLine
-pill: repair
+pill: cli_repair
 subtitle: 'Command-line: repair'
 ---
 # Command-line: repair

--- a/documentation/usage/commandline/undo.md
+++ b/documentation/usage/commandline/undo.md
@@ -1,6 +1,6 @@
 ---
 layout: commandLine
-pill: undo
+pill: cli_undo
 subtitle: 'Command-line: undo'
 ---
 # Command-line: undo

--- a/documentation/usage/commandline/validate.md
+++ b/documentation/usage/commandline/validate.md
@@ -1,6 +1,6 @@
 ---
 layout: commandLine
-pill: validate
+pill: cli_validate
 subtitle: 'Command-line: validate'
 ---
 # Command-line: validate

--- a/documentation/usage/gradle/baseline.md
+++ b/documentation/usage/gradle/baseline.md
@@ -1,6 +1,6 @@
 ---
 layout: gradle
-pill: baseline
+pill: gradle_baseline
 subtitle: 'gradle flywayBaseline'
 ---
 # Gradle Task: flywayBaseline

--- a/documentation/usage/gradle/clean.md
+++ b/documentation/usage/gradle/clean.md
@@ -1,6 +1,6 @@
 ---
 layout: gradle
-pill: clean
+pill: gradle_clean
 subtitle: 'gradle flywayClean'
 ---
 Gradle Task: flywayClean

--- a/documentation/usage/gradle/index.md
+++ b/documentation/usage/gradle/index.md
@@ -1,6 +1,6 @@
 ---
 layout: gradle
-pill: overview
+pill: gradle_overview
 subtitle: Gradle Plugin
 redirect_from: /documentation/gradle
 ---

--- a/documentation/usage/gradle/info.md
+++ b/documentation/usage/gradle/info.md
@@ -1,6 +1,6 @@
 ---
 layout: gradle
-pill: info
+pill: gradle_info
 subtitle: 'gradle flywayInfo'
 ---
 # Gradle Task: flywayInfo

--- a/documentation/usage/gradle/migrate.md
+++ b/documentation/usage/gradle/migrate.md
@@ -1,6 +1,6 @@
 ---
 layout: gradle
-pill: migrate
+pill: gradle_migrate
 subtitle: 'gradle flywayMigrate'
 ---
 # Gradle Task: flywayMigrate

--- a/documentation/usage/gradle/repair.md
+++ b/documentation/usage/gradle/repair.md
@@ -1,6 +1,6 @@
 ---
 layout: gradle
-pill: repair
+pill: gradle_repair
 subtitle: 'gradle flywayRepair'
 ---
 # Gradle Task: flywayRepair

--- a/documentation/usage/gradle/undo.md
+++ b/documentation/usage/gradle/undo.md
@@ -1,6 +1,6 @@
 ---
 layout: gradle
-pill: undo
+pill: gradle_undo
 subtitle: 'gradle flywayUndo'
 ---
 # Gradle Task: flywayUndo

--- a/documentation/usage/gradle/validate.md
+++ b/documentation/usage/gradle/validate.md
@@ -1,6 +1,6 @@
 ---
 layout: gradle
-pill: validate
+pill: gradle_validate
 subtitle: 'gradle flywayValidate'
 ---
 # Gradle Task: flywayValidate

--- a/documentation/usage/maven/baseline.md
+++ b/documentation/usage/maven/baseline.md
@@ -1,6 +1,6 @@
 ---
 layout: maven
-pill: baseline
+pill: mvn_baseline
 subtitle: 'mvn flyway:baseline'
 ---
 # Maven Goal: Baseline

--- a/documentation/usage/maven/clean.md
+++ b/documentation/usage/maven/clean.md
@@ -1,6 +1,6 @@
 ---
 layout: maven
-pill: clean
+pill: mvn_clean
 subtitle: 'mvn flyway:clean'
 ---
 # Maven Goal: Clean

--- a/documentation/usage/maven/index.md
+++ b/documentation/usage/maven/index.md
@@ -1,6 +1,6 @@
 ---
 layout: maven
-pill: overview
+pill: mvn_overview
 subtitle: Maven Plugin
 redirect_from: /documentation/maven
 ---

--- a/documentation/usage/maven/info.md
+++ b/documentation/usage/maven/info.md
@@ -1,6 +1,6 @@
 ---
 layout: maven
-pill: info
+pill: mvn_info
 subtitle: 'mvn flyway:info'
 ---
 # Maven Goal: Info

--- a/documentation/usage/maven/migrate.md
+++ b/documentation/usage/maven/migrate.md
@@ -1,6 +1,6 @@
 ---
 layout: maven
-pill: migrate
+pill: mvn_migrate
 subtitle: 'mvn flyway:migrate'
 ---
 # Maven Goal: Migrate

--- a/documentation/usage/maven/repair.md
+++ b/documentation/usage/maven/repair.md
@@ -1,6 +1,6 @@
 ---
 layout: maven
-pill: repair
+pill: mvn_repair
 subtitle: 'mvn flyway:repair'
 ---
 # Maven Goal: Repair

--- a/documentation/usage/maven/undo.md
+++ b/documentation/usage/maven/undo.md
@@ -1,6 +1,6 @@
 ---
 layout: maven
-pill: undo
+pill: mvn_undo
 subtitle: 'mvn flyway:undo'
 ---
 # Maven Goal: Undo

--- a/documentation/usage/maven/validate.md
+++ b/documentation/usage/maven/validate.md
@@ -1,6 +1,6 @@
 ---
 layout: maven
-pill: validate
+pill: mvn_validate
 subtitle: 'mvn flyway:validate'
 ---
 # Maven Goal: Validate


### PR DESCRIPTION
The sub-pages within the usage pages which show how to execute a command in cli/maven/gradle are now visible in a dropdown