### PR TITLE
Change trial length to match EULA

### DIFF
--- a/documentation/configuration/configfile.md
+++ b/documentation/configuration/configfile.md
@@ -402,7 +402,7 @@ flyway.locations=filesystem:sql
 
 # Your Flyway license key (FL01...). Not yet a Flyway Teams Edition customer?
 # Request your Flyway trial license key st https://flywaydb.org/download/
-# to try out Flyway Teams Edition features free for 30 days.
+# to try out Flyway Teams Edition features free for 28 days.
 # Flyway Teams only
 # flyway.licenseKey=
 ```

--- a/documentation/configuration/parameters/licenseKey.md
+++ b/documentation/configuration/parameters/licenseKey.md
@@ -12,7 +12,7 @@ redirect_from: /documentation/configuration/licenseKey
 ## Description
 Your Flyway license key (`FL01...`) when using Flyway Teams. This should be 516 alpha numeric characters, beginning with `FL`.
 
-Not yet a Flyway Teams Edition customer? Request your <a href="" data-toggle="modal" data-target="#flyway-trial-license-modal">Flyway trial license key</a> to try out Flyway Teams Edition features free for 30 days.
+Not yet a Flyway Teams Edition customer? Request your <a href="" data-toggle="modal" data-target="#flyway-trial-license-modal">Flyway trial license key</a> to try out Flyway Teams Edition features free for 28 days.
 
 ## Usage
 

--- a/documentation/usage/api/javadoc/org/flywaydb/core/api/configuration/ClassicConfiguration.html
+++ b/documentation/usage/api/javadoc/org/flywaydb/core/api/configuration/ClassicConfiguration.html
@@ -2071,7 +2071,7 @@ implements <a href="Configuration.html" title="interface in org.flywaydb.core.ap
 <div class="block"><span class="descfrmTypeLabel">Description copied from interface:&nbsp;<code><a href="Configuration.html#getLicenseKey()">Configuration</a></code></span></div>
 <div class="block">Your Flyway license key (FL01...). Not yet a Flyway Teams Edition customer?
  Request your <a href="https://flywaydb.org/download/">Flyway trial license key</a>
- to try out Flyway Teams Edition features free for 30 days.
+ to try out Flyway Teams Edition features free for 28 days.
 
  <p><i>Flyway Teams only</i></p></div>
 <dl>
@@ -3357,7 +3357,7 @@ implements <a href="Configuration.html" title="interface in org.flywaydb.core.ap
 <pre class="methodSignature">public&nbsp;void&nbsp;setLicenseKey&#8203;(java.lang.String&nbsp;licenseKey)</pre>
 <div class="block">Your Flyway license key (FL01...). Not yet a Flyway Teams Edition customer?
  Request your <a href="https://flywaydb.org/download/">Flyway trial license key</a>
- to try out Flyway Teams Edition features free for 30 days.
+ to try out Flyway Teams Edition features free for 28 days.
 
  <p><i>Flyway Teams only</i></p></div>
 <dl>

--- a/documentation/usage/api/javadoc/org/flywaydb/core/api/configuration/Configuration.html
+++ b/documentation/usage/api/javadoc/org/flywaydb/core/api/configuration/Configuration.html
@@ -1466,7 +1466,7 @@ $('.navPadding').css('padding-top', $('.fixedNav').css("height"));
 <pre class="methodSignature">java.lang.String&nbsp;getLicenseKey()</pre>
 <div class="block">Your Flyway license key (FL01...). Not yet a Flyway Teams Edition customer?
  Request your <a href="https://flywaydb.org/download/">Flyway trial license key</a>
- to try out Flyway Teams Edition features free for 30 days.
+ to try out Flyway Teams Edition features free for 28 days.
 
  <p><i>Flyway Teams only</i></p></div>
 <dl>

--- a/documentation/usage/api/javadoc/org/flywaydb/core/api/configuration/FluentConfiguration.html
+++ b/documentation/usage/api/javadoc/org/flywaydb/core/api/configuration/FluentConfiguration.html
@@ -2202,7 +2202,7 @@ implements <a href="Configuration.html" title="interface in org.flywaydb.core.ap
 <div class="block"><span class="descfrmTypeLabel">Description copied from interface:&nbsp;<code><a href="Configuration.html#getLicenseKey()">Configuration</a></code></span></div>
 <div class="block">Your Flyway license key (FL01...). Not yet a Flyway Teams Edition customer?
  Request your <a href="https://flywaydb.org/download/">Flyway trial license key</a>
- to try out Flyway Teams Edition features free for 30 days.
+ to try out Flyway Teams Edition features free for 28 days.
 
  <p><i>Flyway Teams only</i></p></div>
 <dl>
@@ -3356,7 +3356,7 @@ implements <a href="Configuration.html" title="interface in org.flywaydb.core.ap
 <pre class="methodSignature">public&nbsp;<a href="FluentConfiguration.html" title="class in org.flywaydb.core.api.configuration">FluentConfiguration</a>&nbsp;licenseKey&#8203;(java.lang.String&nbsp;licenseKey)</pre>
 <div class="block">Your Flyway license key (FL01...). Not yet a Flyway Teams Edition customer?
  Request your <a href="https://flywaydb.org/download/">Flyway trial license key</a>
- to try out Flyway Teams Edition features free for 30 days.
+ to try out Flyway Teams Edition features free for 28 days.
 
  <p><i>Flyway Teams only</i></p></div>
 <dl>

--- a/download/faq.md
+++ b/download/faq.md
@@ -36,7 +36,7 @@ least March 2022. After that date support will be retired from Community Edition
 ## Is there a trial version?
 
 Yes there is. All you need to do is <a href="" data-toggle="modal" data-target="#flyway-trial-license-modal">request a trial license key</a>.
-This license key is valid for 30 days and can be used with Flyway Teams. After 30 days
+This license key is valid for 28 days and can be used with Flyway Teams. After 28 days
 you must either upgrade to a full Flyway Teams Edition license or downgrade to
 Flyway Community Edition. The trial comes with the full functionality of the Flyway Teams Edition,
 except for the source code, which is only available to paying customers.

--- a/download/index.md
+++ b/download/index.md
@@ -48,7 +48,7 @@ Choose your Flyway edition based on the features and support level you require
 <tr><td>Automatic renewal</td><td></td><td>optional</td></tr>
 <tr><td>Payment methods accepted</td><td></td><td>Credit card, wire transfer, purchase order</td></tr>
 <tr><td></td><td></td>
-<td><button class="btn btn-primary btn-download" data-toggle="modal" data-target="#flyway-trial-license-modal">Start Free Trial <i class="fa fa-arrow-right"></i><br><span class="note">License key for 30 days</span></button></td>
+<td><button class="btn btn-primary btn-download" data-toggle="modal" data-target="#flyway-trial-license-modal">Start Free Trial <i class="fa fa-arrow-right"></i><br><span class="note">License key for 28 days</span></button></td>
 </tr>
 <tr><td></td>
 <td></td>


### PR DESCRIPTION
This PR changes the documentation of Flyway's trial period from 30 days to 28 days, inline with the Flyway Teams commercial EULA.

- ![Screenshot 2020-10-15 at 17 12 26](https://user-images.githubusercontent.com/13132227/96156962-9e4e8380-0f09-11eb-840b-61a6acd9a8fc.png)
 - ![Screenshot 2020-10-15 at 17 10 52](https://user-images.githubusercontent.com/13132227/96156978-a27aa100-0f09-11eb-9143-bbca07a7550e.png)
- ![Screenshot 2020-10-15 at 17 11 30](https://user-images.githubusercontent.com/13132227/96156987-a4dcfb00-0f09-11eb-84de-ae6a7b855976.png)
