### PR TITLE
Update placeholders documentation page

### DIFF
--- a/documentation/configuration/parameters/placeholders.md
+++ b/documentation/configuration/parameters/placeholders.md
@@ -20,7 +20,7 @@ Placeholder matching is case insensitive, so a placeholder of `flyway.placeholde
 
 ### Commandline
 ```powershell
-./flyway -flyway.placeholders.key1=value1 -flyway.placeholders.key2=value2 info
+./flyway -placeholders.key1=value1 -placeholders.key2=value2 info
 ```
 
 ### Configuration File


### PR DESCRIPTION
Remove unnecessary prefix from placeholders cli example

```
> flyway -configFiles="flyway.properties" -flyway.placeholders.env="dev" migrate -X

ERROR: Unexpected error
org.flywaydb.core.api.FlywayException: Unknown configuration property: flyway.flyway.placeholders.env
        at org.flywaydb.core.internal.configuration.ConfigUtils.checkConfigurationForUnrecognisedProperties(ConfigUtils.java:616)
        at org.flywaydb.core.api.configuration.ClassicConfiguration.configure(ClassicConfiguration.java:2305)
        at org.flywaydb.core.api.configuration.FluentConfiguration.configuration(FluentConfiguration.java:1197)
        at org.flywaydb.commandline.Main.main(Main.java:147)
```