### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 ifeq ($(OS), Windows_NT)
 FORCE_POLLING = true
 else
-FORCE_POLLING = false
+	FORCE_POLLING = false
+	UNAME_S := $(shell uname -s)
+	ifeq ($(UNAME_S),Darwin)
+		FORCE_POLLING = true
+	endif
 endif
 
 all: clean run


### PR DESCRIPTION
When developing the website locally on MacOS, Jekyll's LiveReload wasn't working because of the OS check excluded Darwin and incorrectly set FORCE_POLLING to false.

This PR updates the Makefile to ensure MacOS is picked up in OS check, setting FORCE_POLLING to true for MacOS and enabling Jekyll LiveReload when running site locally in dev on a Mac.