### PR TITLE
Link to command usage pages from command pages

### DIFF
--- a/_includes/commandUsage.html
+++ b/_includes/commandUsage.html
@@ -1,0 +1,24 @@
+<div class="tabbable">
+	<ul class="nav nav-tabs">
+		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
+			Command-line</a></li>
+		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
+		</li>
+		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
+		</li>
+	</ul>
+	<div class="tab-content">
+		<div class="tab-pane active" id="tab-commandline">
+			<a href="/documentation/usage/commandline/{{include.command}}" class="btn btn-primary">How to {{include.command}} in the
+				Command-line Tool <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-maven">
+			<a href="/documentation/usage/maven/{{include.command}}" class="btn btn-primary">How to {{include.command}} in the
+				Maven Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-gradle">
+			<a href="/documentation/usage/gradle/{{include.command}}" class="btn btn-primary">How to {{include.command}} in the
+				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+	</div>
+</div>

--- a/documentation/command/baseline.md
+++ b/documentation/command/baseline.md
@@ -13,7 +13,32 @@ Baseline is for introducing Flyway to [existing databases](/documentation/learnm
 at a specific version. This will cause [Migrate](/documentation/command/migrate) to ignore all migrations
 up to and including the baseline version. Newer migrations will then be applied as usual.
 
+## Usage
 See [configuration](/documentation/configuration/parameters/#baseline) for baseline specific configuration parameters.
+<div class="tabbable">
+	<ul class="nav nav-tabs">
+		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
+			Command-line</a></li>
+		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
+		</li>
+		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
+		</li>
+	</ul>
+	<div class="tab-content">
+		<div class="tab-pane active" id="tab-commandline">
+			<a href="/documentation/usage/commandline/baseline" class="btn btn-primary">How to baseline in the
+				Command-line Tool <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-maven">
+			<a href="/documentation/usage/maven/baseline" class="btn btn-primary">How to baseline in the
+				Maven Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-gradle">
+			<a href="/documentation/usage/gradle/baseline" class="btn btn-primary">How to baseline in the
+				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+	</div>
+</div>
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/repair">Repair <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/baseline.md
+++ b/documentation/command/baseline.md
@@ -15,30 +15,7 @@ up to and including the baseline version. Newer migrations will then be applied 
 
 ## Usage
 See [configuration](/documentation/configuration/parameters/#baseline) for baseline specific configuration parameters.
-<div class="tabbable">
-	<ul class="nav nav-tabs">
-		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
-			Command-line</a></li>
-		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
-		</li>
-		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
-		</li>
-	</ul>
-	<div class="tab-content">
-		<div class="tab-pane active" id="tab-commandline">
-			<a href="/documentation/usage/commandline/baseline" class="btn btn-primary">How to baseline in the
-				Command-line Tool <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-maven">
-			<a href="/documentation/usage/maven/baseline" class="btn btn-primary">How to baseline in the
-				Maven Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-gradle">
-			<a href="/documentation/usage/gradle/baseline" class="btn btn-primary">How to baseline in the
-				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-	</div>
-</div>
+{% include commandUsage.html command="baseline" %}
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/repair">Repair <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/clean.md
+++ b/documentation/command/clean.md
@@ -14,7 +14,32 @@ Clean is a great help in development and test. It will effectively give you a fr
 
 Needless to say: **do not use against your production DB!**
 
+## Usage
 See [configuration](/documentation/configuration/parameters/#clean) for clean specific configuration parameters.
+<div class="tabbable">
+	<ul class="nav nav-tabs">
+		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
+			Command-line</a></li>
+		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
+		</li>
+		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
+		</li>
+	</ul>
+	<div class="tab-content">
+		<div class="tab-pane active" id="tab-commandline">
+			<a href="/documentation/usage/commandline/clean" class="btn btn-primary">How to clean in the
+				Command-line Tool <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-maven">
+			<a href="/documentation/usage/maven/clean" class="btn btn-primary">How to clean in the
+				Maven Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-gradle">
+			<a href="/documentation/usage/gradle/clean" class="btn btn-primary">How to clean in the
+				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+	</div>
+</div>
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/info">Info <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/clean.md
+++ b/documentation/command/clean.md
@@ -16,30 +16,7 @@ Needless to say: **do not use against your production DB!**
 
 ## Usage
 See [configuration](/documentation/configuration/parameters/#clean) for clean specific configuration parameters.
-<div class="tabbable">
-	<ul class="nav nav-tabs">
-		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
-			Command-line</a></li>
-		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
-		</li>
-		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
-		</li>
-	</ul>
-	<div class="tab-content">
-		<div class="tab-pane active" id="tab-commandline">
-			<a href="/documentation/usage/commandline/clean" class="btn btn-primary">How to clean in the
-				Command-line Tool <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-maven">
-			<a href="/documentation/usage/maven/clean" class="btn btn-primary">How to clean in the
-				Maven Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-gradle">
-			<a href="/documentation/usage/gradle/clean" class="btn btn-primary">How to clean in the
-				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-	</div>
-</div>
+{% include commandUsage.html command="clean" %}
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/info">Info <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/info.md
+++ b/documentation/command/info.md
@@ -12,6 +12,32 @@ Prints the details and status information about all the migrations.
 Info lets you know where you stand. At a glance you will see which migrations have already been applied,
 which other ones are still pending, when they were executed and whether they were successful or not.
 
+## Usage
+<div class="tabbable">
+	<ul class="nav nav-tabs">
+		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
+			Command-line</a></li>
+		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
+		</li>
+		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
+		</li>
+	</ul>
+	<div class="tab-content">
+		<div class="tab-pane active" id="tab-commandline">
+			<a href="/documentation/usage/commandline/info" class="btn btn-primary">How to info in the
+				Command-line Tool <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-maven">
+			<a href="/documentation/usage/maven/info" class="btn btn-primary">How to info in the
+				Maven Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-gradle">
+			<a href="/documentation/usage/gradle/info" class="btn btn-primary">How to info in the
+				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+	</div>
+</div>
+
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/validate">Validate <i class="fa fa-arrow-right"></i></a>
 </p>

--- a/documentation/command/info.md
+++ b/documentation/command/info.md
@@ -13,30 +13,7 @@ Info lets you know where you stand. At a glance you will see which migrations ha
 which other ones are still pending, when they were executed and whether they were successful or not.
 
 ## Usage
-<div class="tabbable">
-	<ul class="nav nav-tabs">
-		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
-			Command-line</a></li>
-		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
-		</li>
-		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
-		</li>
-	</ul>
-	<div class="tab-content">
-		<div class="tab-pane active" id="tab-commandline">
-			<a href="/documentation/usage/commandline/info" class="btn btn-primary">How to info in the
-				Command-line Tool <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-maven">
-			<a href="/documentation/usage/maven/info" class="btn btn-primary">How to info in the
-				Maven Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-gradle">
-			<a href="/documentation/usage/gradle/info" class="btn btn-primary">How to info in the
-				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-	</div>
-</div>
+{% include commandUsage.html command="info" %}
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/validate">Validate <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/migrate.md
+++ b/documentation/command/migrate.md
@@ -29,30 +29,7 @@ Migrate will apply the migrations 6, 7, 8 and 9 in order.
 Migrate does nothing.
 
 ## Usage
-<div class="tabbable">
-	<ul class="nav nav-tabs">
-		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
-			Command-line</a></li>
-		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
-		</li>
-		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
-		</li>
-	</ul>
-	<div class="tab-content">
-		<div class="tab-pane active" id="tab-commandline">
-			<a href="/documentation/usage/commandline/migrate" class="btn btn-primary">How to migrate in the
-				Command-line Tool <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-maven">
-			<a href="/documentation/usage/maven/migrate" class="btn btn-primary">How to migrate in the
-				Maven Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-gradle">
-			<a href="/documentation/usage/gradle/migrate" class="btn btn-primary">How to migrate in the
-				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-	</div>
-</div>
+{% include commandUsage.html command="migrate" %}
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/clean">Clean <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/migrate.md
+++ b/documentation/command/migrate.md
@@ -28,6 +28,32 @@ Migrate will apply the migrations 6, 7, 8 and 9 in order.
 
 Migrate does nothing.
 
+## Usage
+<div class="tabbable">
+	<ul class="nav nav-tabs">
+		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
+			Command-line</a></li>
+		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
+		</li>
+		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
+		</li>
+	</ul>
+	<div class="tab-content">
+		<div class="tab-pane active" id="tab-commandline">
+			<a href="/documentation/usage/commandline/migrate" class="btn btn-primary">How to migrate in the
+				Command-line Tool <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-maven">
+			<a href="/documentation/usage/maven/migrate" class="btn btn-primary">How to migrate in the
+				Maven Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-gradle">
+			<a href="/documentation/usage/gradle/migrate" class="btn btn-primary">How to migrate in the
+				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+	</div>
+</div>
+
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/clean">Clean <i class="fa fa-arrow-right"></i></a>
 </p>

--- a/documentation/command/repair.md
+++ b/documentation/command/repair.md
@@ -14,6 +14,32 @@ Repair is your tool to fix issues with the schema history table. It has a few ma
 - Realign the checksums, descriptions, and types of the applied migrations with the ones of the available migrations
 - Mark all missing migrations as **deleted**
 
+## Usage
+<div class="tabbable">
+	<ul class="nav nav-tabs">
+		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
+			Command-line</a></li>
+		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
+		</li>
+		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
+		</li>
+	</ul>
+	<div class="tab-content">
+		<div class="tab-pane active" id="tab-commandline">
+			<a href="/documentation/usage/commandline/repair" class="btn btn-primary">How to repair in the
+				Command-line Tool <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-maven">
+			<a href="/documentation/usage/maven/repair" class="btn btn-primary">How to repair in the
+				Maven Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-gradle">
+			<a href="/documentation/usage/gradle/repair" class="btn btn-primary">How to repair in the
+				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+	</div>
+</div>
+
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/usage/commandline/">Command-line <i class="fa fa-arrow-right"></i></a>
 </p>

--- a/documentation/command/repair.md
+++ b/documentation/command/repair.md
@@ -15,30 +15,7 @@ Repair is your tool to fix issues with the schema history table. It has a few ma
 - Mark all missing migrations as **deleted**
 
 ## Usage
-<div class="tabbable">
-	<ul class="nav nav-tabs">
-		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
-			Command-line</a></li>
-		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
-		</li>
-		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
-		</li>
-	</ul>
-	<div class="tab-content">
-		<div class="tab-pane active" id="tab-commandline">
-			<a href="/documentation/usage/commandline/repair" class="btn btn-primary">How to repair in the
-				Command-line Tool <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-maven">
-			<a href="/documentation/usage/maven/repair" class="btn btn-primary">How to repair in the
-				Maven Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-gradle">
-			<a href="/documentation/usage/gradle/repair" class="btn btn-primary">How to repair in the
-				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-	</div>
-</div>
+{% include commandUsage.html command="repair" %}
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/usage/commandline/">Command-line <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/undo.md
+++ b/documentation/command/undo.md
@@ -43,30 +43,7 @@ technology of your underlying storage solution. Especially for larger data volum
 several orders of magnitude faster than traditional backups and restores.
 
 ## Usage
-<div class="tabbable">
-	<ul class="nav nav-tabs">
-		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
-			Command-line</a></li>
-		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
-		</li>
-		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
-		</li>
-	</ul>
-	<div class="tab-content">
-		<div class="tab-pane active" id="tab-commandline">
-			<a href="/documentation/usage/commandline/undo" class="btn btn-primary">How to undo in the
-				Command-line Tool <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-maven">
-			<a href="/documentation/usage/maven/undo" class="btn btn-primary">How to undo in the
-				Maven Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-gradle">
-			<a href="/documentation/usage/gradle/undo" class="btn btn-primary">How to undo in the
-				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-	</div>
-</div>
+{% include commandUsage.html command="undo" %}
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/baseline">Baseline <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/undo.md
+++ b/documentation/command/undo.md
@@ -42,6 +42,32 @@ optimal performance, and if your infrastructure supports this, we recommend usin
 technology of your underlying storage solution. Especially for larger data volumes, this can be
 several orders of magnitude faster than traditional backups and restores.
 
+## Usage
+<div class="tabbable">
+	<ul class="nav nav-tabs">
+		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
+			Command-line</a></li>
+		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
+		</li>
+		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
+		</li>
+	</ul>
+	<div class="tab-content">
+		<div class="tab-pane active" id="tab-commandline">
+			<a href="/documentation/usage/commandline/undo" class="btn btn-primary">How to undo in the
+				Command-line Tool <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-maven">
+			<a href="/documentation/usage/maven/undo" class="btn btn-primary">How to undo in the
+				Maven Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-gradle">
+			<a href="/documentation/usage/gradle/undo" class="btn btn-primary">How to undo in the
+				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+	</div>
+</div>
+
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/baseline">Baseline <i class="fa fa-arrow-right"></i></a>
 </p>

--- a/documentation/command/validate.md
+++ b/documentation/command/validate.md
@@ -17,30 +17,7 @@ Validate works by storing a checksum (CRC32 for SQL migrations) when a migration
 
 ## Usage
 See [configuration](/documentation/configuration/parameters/#validate) for validate specific configuration parameters.
-<div class="tabbable">
-	<ul class="nav nav-tabs">
-		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
-			Command-line</a></li>
-		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
-		</li>
-		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
-		</li>
-	</ul>
-	<div class="tab-content">
-		<div class="tab-pane active" id="tab-commandline">
-			<a href="/documentation/usage/commandline/validate" class="btn btn-primary">How to validate in the
-				Command-line Tool <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-maven">
-			<a href="/documentation/usage/maven/validate" class="btn btn-primary">How to validate in the
-				Maven Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-		<div class="tab-pane" id="tab-gradle">
-			<a href="/documentation/usage/gradle/validate" class="btn btn-primary">How to validate in the
-				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
-		</div>
-	</div>
-</div>
+{% include commandUsage.html command="validate" %}
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/undo">Undo <i class="fa fa-arrow-right"></i></a>

--- a/documentation/command/validate.md
+++ b/documentation/command/validate.md
@@ -15,7 +15,32 @@ This is very useful to detect accidental changes that may prevent you from relia
 
 Validate works by storing a checksum (CRC32 for SQL migrations) when a migration is executed. The validate mechanism checks if the migration locally still has the same checksum as the migration already executed in the database.
 
+## Usage
 See [configuration](/documentation/configuration/parameters/#validate) for validate specific configuration parameters.
+<div class="tabbable">
+	<ul class="nav nav-tabs">
+		<li class="active marketing-item"><a href="#tab-commandline" data-toggle="tab"><i class="fa fa-desktop"></i>
+			Command-line</a></li>
+		<li class="marketing-item"><a href="#tab-maven" data-toggle="tab"><i class="fa fa-maxcdn"></i> Maven</a>
+		</li>
+		<li class="marketing-item"><a href="#tab-gradle" data-toggle="tab"><i class="fa fa-cogs"></i> Gradle</a>
+		</li>
+	</ul>
+	<div class="tab-content">
+		<div class="tab-pane active" id="tab-commandline">
+			<a href="/documentation/usage/commandline/validate" class="btn btn-primary">How to validate in the
+				Command-line Tool <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-maven">
+			<a href="/documentation/usage/maven/validate" class="btn btn-primary">How to validate in the
+				Maven Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+		<div class="tab-pane" id="tab-gradle">
+			<a href="/documentation/usage/gradle/validate" class="btn btn-primary">How to validate in the
+				Gradle Plugin <i class="fa fa-arrow-right"></i></a>
+		</div>
+	</div>
+</div>
 
 <p class="next-steps">
     <a class="btn btn-primary" href="/documentation/command/undo">Undo <i class="fa fa-arrow-right"></i></a>


### PR DESCRIPTION
Adds this block to each page:

![image](https://user-images.githubusercontent.com/1607501/96614142-ae92a400-12f7-11eb-8cf3-a5a2c166303d.png)

Note: Theres no link to for the api as we havent written api usage pages for each command. If we ever do that, we can add links to them.