### PR TITLE
Example use cases for some config params

### DIFF
--- a/documentation/configuration/parameters/batch.md
+++ b/documentation/configuration/parameters/batch.md
@@ -56,3 +56,9 @@ flyway {
     <batch>true</batch>
 </configuration>
 ```
+
+## Use Cases
+
+### Improving performance by reducing communication overhead
+
+Suppose you have 1000 statements in a migration, and your communication overhead is 0.1 second. Without batching the migrate process would have a 1000 x 0.1 = 100 second overhead in communication (sending the statements) alone. This is a lot of time. With `batch` enabled, 100 statements can be sent at a time, meaning the communication overhead is only incurred 1000/100 = 10 times, resulting in a 10 x 0.1 = 1 second migrate overhead due to communication.

--- a/documentation/configuration/parameters/cherryPick.md
+++ b/documentation/configuration/parameters/cherryPick.md
@@ -57,3 +57,9 @@ flyway {
     <cherryPick>2.0</cherryPick>
 </configuration>
 ```
+
+## Use Cases
+
+### Deferred migration execution
+
+Let's say you have a project with 3 migrations: `V1__fastCreate1.sql`, `V2__slowInsert.sql` and `V3__fastCreate2.sql`. Migration `V2` takes a tremendously large amount of time to execute so you decide executing it overnight would be better, but still need to execute the other migrations. Without `cherryPick` this would involve deleting `V2` from disk and adding it back when needed which is a tedious and error prone task. Using `cherryPick` we can simply migrate `V1` and `V3` immediately: `flyway migrate -cherryPick="1,3"`. When it comes to migrating `V2`, we can utilise [outOfOrder](http://localhost:4000/documentation/configuration/parameters/outOfOrder) as follows: `flyway migrate -cherryPick="2" -outOfOrder="true"`.

--- a/documentation/configuration/parameters/cherryPick.md
+++ b/documentation/configuration/parameters/cherryPick.md
@@ -76,7 +76,7 @@ Migration `V2` takes a tremendously large amount of time to execute so you decid
 flyway migrate -cherryPick="1,3"
 ```
 
-When it comes to migrating `V2`, we can utilise [outOfOrder](http://localhost:4000/documentation/configuration/parameters/outOfOrder) as follows:
+When it comes to migrating `V2`, we can utilise [outOfOrder](/documentation/configuration/parameters/outOfOrder) as follows:
 
 ```
 flyway migrate -cherryPick="2" -outOfOrder="true"

--- a/documentation/configuration/parameters/cherryPick.md
+++ b/documentation/configuration/parameters/cherryPick.md
@@ -62,4 +62,22 @@ flyway {
 
 ### Deferred migration execution
 
-Let's say you have a project with 3 migrations: `V1__fastCreate1.sql`, `V2__slowInsert.sql` and `V3__fastCreate2.sql`. Migration `V2` takes a tremendously large amount of time to execute so you decide executing it overnight would be better, but still need to execute the other migrations. Without `cherryPick` this would involve deleting `V2` from disk and adding it back when needed which is a tedious and error prone task. Using `cherryPick` we can simply migrate `V1` and `V3` immediately: `flyway migrate -cherryPick="1,3"`. When it comes to migrating `V2`, we can utilise [outOfOrder](http://localhost:4000/documentation/configuration/parameters/outOfOrder) as follows: `flyway migrate -cherryPick="2" -outOfOrder="true"`.
+Let's say you have a project with 3 migrations:
+
+```
+V1__fastCreate1.sql
+V2__slowInsert2.sql
+V3__fastCreate3.sql
+```
+
+Migration `V2` takes a tremendously large amount of time to execute so you decide executing it overnight would be better, but still need to execute migrations `V1` and `V3`. Without `cherryPick` this would involve deleting `V2` from disk and adding it back when needed which is a tedious and error prone task. Using `cherryPick` we can simply migrate `V1` and `V3` immediately:
+
+```
+flyway migrate -cherryPick="1,3"
+```
+
+When it comes to migrating `V2`, we can utilise [outOfOrder](http://localhost:4000/documentation/configuration/parameters/outOfOrder) as follows:
+
+```
+flyway migrate -cherryPick="2" -outOfOrder="true"
+```

--- a/documentation/configuration/parameters/dryRunOutput.md
+++ b/documentation/configuration/parameters/dryRunOutput.md
@@ -61,4 +61,18 @@ flyway {
 
 ### Preview changes without altering the database
 
-Quite often a migration may be making use of [placeholders](http://localhost:4000/documentation/configuration/parameters/placeholders), such as in the statement `INSERT INTO table1(name) VALUES(${name})`. There may also be callbacks executing as part of your migration process which you might not be aware of when developing migrations. Instead of risking errors when migrating against your actual database with these unknowns, you can use dry runs to generate the SQL that would be executed in order to preview what would happen without altering the database. For example, you may notice that the placeholder `${name}` isn't what you expected, or that there is a callback being executed before your migration which you aren't accounting for.
+Quite often a migration may be making use of [placeholders](http://localhost:4000/documentation/configuration/parameters/placeholders), such as in the following statement:
+
+```
+INSERT INTO table1(name) VALUES('${name}')
+```
+
+There may also be callbacks executing as part of your migration process which you might not be aware of when developing migrations. Instead of risking errors when migrating against your actual database with these unknowns, you can use dry runs to generate the SQL that would be executed in order to preview what would happen without altering the database. For example, you may notice that the placeholder `${name}` isn't what you expected. Part of the dry run might show as:
+
+```
+-- Source: ./V1__insert1.sql
+---------------------------
+INSERT INTO table1(name) VALUES('XYZ')
+```
+
+You may have expected `${name}` to be `ABC` instead of `XYZ`. There could also be a callback being executed before your migration which you aren't accounting for.

--- a/documentation/configuration/parameters/dryRunOutput.md
+++ b/documentation/configuration/parameters/dryRunOutput.md
@@ -61,7 +61,7 @@ flyway {
 
 ### Preview changes without altering the database
 
-Quite often a migration may be making use of [placeholders](http://localhost:4000/documentation/configuration/parameters/placeholders), such as in the following statement:
+Quite often a migration may be making use of [placeholders](/documentation/configuration/parameters/placeholders), such as in the following statement:
 
 ```
 INSERT INTO table1(name) VALUES('${name}')

--- a/documentation/configuration/parameters/dryRunOutput.md
+++ b/documentation/configuration/parameters/dryRunOutput.md
@@ -56,3 +56,9 @@ flyway {
     <dryRunOutput>/my/output/file.sql</dryRunOutput>
 </configuration>
 ```
+
+## Use Cases
+
+### Preview changes without altering the database
+
+Quite often a migration may be making use of [placeholders](http://localhost:4000/documentation/configuration/parameters/placeholders), such as in the statement `INSERT INTO table1(name) VALUES(${name})`. There may also be callbacks executing as part of your migration process which you might not be aware of when developing migrations. Instead of risking errors when migrating against your actual database with these unknowns, you can use dry runs to generate the SQL that would be executed in order to preview what would happen without altering the database. For example, you may notice that the placeholder `${name}` isn't what you expected, or that there is a callback being executed before your migration which you aren't accounting for.

--- a/documentation/configuration/parameters/errorOverrides.md
+++ b/documentation/configuration/parameters/errorOverrides.md
@@ -74,4 +74,4 @@ flyway {
 
 ## Use Cases
 
-See our [error overrides examples](http://localhost:4000/documentation/concepts/erroroverrides#examples).
+See our [error overrides examples](/documentation/concepts/erroroverrides#examples).

--- a/documentation/configuration/parameters/errorOverrides.md
+++ b/documentation/configuration/parameters/errorOverrides.md
@@ -74,4 +74,4 @@ flyway {
 
 ## Use Cases
 
-- See our [error overrides examples](http://localhost:4000/documentation/concepts/erroroverrides#examples)
+See our [error overrides examples](http://localhost:4000/documentation/concepts/erroroverrides#examples).

--- a/documentation/configuration/parameters/errorOverrides.md
+++ b/documentation/configuration/parameters/errorOverrides.md
@@ -71,3 +71,7 @@ flyway {
     <errorOverrides>STATE:12345:W</errorOverrides>
 </configuration>
 ```
+
+## Use Cases
+
+- See our [error overrides examples](http://localhost:4000/documentation/concepts/erroroverrides#examples)

--- a/documentation/configuration/parameters/jdbcProperties.md
+++ b/documentation/configuration/parameters/jdbcProperties.md
@@ -61,4 +61,4 @@ flyway {
 
 ### Passing access tokens
 
-Some database JDBC drivers support authentication with access tokens, but this token may not be supported in the URL (see [SQL Server Azure Active Directory](http://localhost:4000/documentation/database/sqlserver#azure-active-directory)). You may also not want to leak information such as tokens in the URL. In these cases, an additional properties object can be passed to the JDBC driver which can be configured with `jdbcProperties` allowing you to achieve, for example, authentication that wasn't previously possible.
+Some database JDBC drivers support authentication with access tokens, but this token may not be supported in the URL (see [SQL Server Azure Active Directory](/documentation/database/sqlserver#azure-active-directory)). You may also not want to leak information such as tokens in the URL. In these cases, an additional properties object can be passed to the JDBC driver which can be configured with `jdbcProperties` allowing you to achieve, for example, authentication that wasn't previously possible.

--- a/documentation/configuration/parameters/jdbcProperties.md
+++ b/documentation/configuration/parameters/jdbcProperties.md
@@ -56,3 +56,9 @@ flyway {
     </jdbcProperties>
 </configuration>
 ```
+
+## Use Cases
+
+### Passing access tokens
+
+Some database JDBC drivers support authentication with access tokens, but this token may not be supported in the URL (see [SQL Server Azure Active Directory](http://localhost:4000/documentation/database/sqlserver#azure-active-directory)). You may also not want to leak information such as tokens in the URL. In these cases, an additional properties object can be passed to the JDBC driver which can be configured with `jdbcProperties` allowing you to achieve, for example, authentication that wasn't previously possible.

--- a/documentation/configuration/parameters/oracleSqlPlus.md
+++ b/documentation/configuration/parameters/oracleSqlPlus.md
@@ -57,5 +57,4 @@ flyway {
 
 ### Configuring consistent sessions for your migrations
 
-See [site and user profiles](/documentation/database/oracle#site-profiles-gloginsql--user-profiles-loginsql) to learn about how this is achieved with
-Oracle SQL*Plus.
+See our list of [supported SQL\*Plus commands](/documentation/database/oracle#sqlplus-commands) and how you can utilize them with [site and user profiles](/documentation/database/oracle#site-profiles-gloginsql--user-profiles-loginsql) once SQL\*Plus is enable to achieved this.

--- a/documentation/configuration/parameters/oracleSqlPlus.md
+++ b/documentation/configuration/parameters/oracleSqlPlus.md
@@ -52,3 +52,10 @@ flyway {
     <oracleSqlplus>true</oracleSqlplus>
 </configuration>
 ```
+
+## Use Cases
+
+### Configuring consistent sessions for your migrations
+
+See [site and user profiles](/documentation/database/oracle#site-profiles-gloginsql--user-profiles-loginsql) to learn about how this is achieved with
+Oracle SQL*Plus.

--- a/documentation/configuration/parameters/outputQueryResults.md
+++ b/documentation/configuration/parameters/outputQueryResults.md
@@ -52,3 +52,15 @@ flyway {
     <outputQueryResults>false</outputQueryResults>
 </configuration>
 ```
+
+## Use Cases
+
+### Checking the result of your migrations
+
+When developing and testing migrations, you often want to do a sanity check to ensure that they behave and return expected values. For example, you may have applied some migrations that insert data. You could then also execute a select query such as:
+
+```
+SELECT * FROM my_table
+```
+
+With `outputQueryResults` enabled the result of this `SELECT` will be printed for you to inspect and verify before you continue.

--- a/documentation/configuration/parameters/skipExecutingMigrations.md
+++ b/documentation/configuration/parameters/skipExecutingMigrations.md
@@ -61,4 +61,10 @@ flyway {
 
 ## Related Reading
 
+See the following articles for additional information on `skipExecutingMigrations` along with examples and use cases.
+
 - [Blog Post: Skip Executing Migrations Examples](/blog/skipExecutingMigrations)
+    - [Hotfixes](/blog/skipExecutingMigrations#hotfixes)
+    - [Migration Generation](/blog/skipExecutingMigrations#migration-generation)
+    - [Deferred Migration Execution](/blog/skipExecutingMigrations#deferred-migration-execution)
+    - [Intermediate Baseline](/blog/skipExecutingMigrations#intermediate-baseline)


### PR DESCRIPTION
This adds a use case to some relevant teams only parameters (excluding parameters like licenseKey or oracleSqlplusWarn which don't need an example or where the description is enough)