### PR TITLE
Specify host in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,9 @@ clean:
 run:
 	docker run --rm \
 		-v "$(realpath .):/srv/jekyll" \
+		-h localhost \
 		-p 35729:35729 -p 4000:4000 \
 		-e FORCE_POLLING=$(FORCE_POLLING) \
 		-e PAGES_REPO_NWO='flyway/flywaydb.org' \
 		-it jekyll/jekyll:3.8 \
-		jekyll serve --livereload --incremental
+		jekyll serve --livereload --incremental --host localhost


### PR DESCRIPTION
The redirects weren't working when running locally, and this _seems_ to fix it.

Something to do with how Jekyll defaults to 0.0.0.0, and the fact that we're running it with docker.