### PR TITLE
Add steps to configure & use Spawn in the command-line getting started docs

### DIFF
--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -15,20 +15,33 @@ This tutorial should take you about **10 minutes** to complete.
 
 Start by <a href="/download">downloading the Flyway Command-line Tool</a> for your platform and extract it.
 
-Let's jump into our new directory:
-
-<pre class="console"><span>&gt;</span> cd flyway-{{ site.flywayVersion }}</pre>
-
 Install Spawn by visiting the <a href="https://www.spawn.cc/docs/getting-started.html">getting started documentation</a> and following the installation steps.
 
 ## Configuring Flyway
 
-Once that is done, configure Flyway by editing `/conf/flyway.conf` like this:
+To configure Flyway, we first need a database we can connect to. We’ll use Spawn to create your own, isolated database environment from which you can run migrations against. This will create you your first data container, which is your database instance:
+
+<pre class="console"><span>&gt;</span> spawnctl create data-container --image postgres:empty --name flyway-container</pre>
+
+This will return connection string details which is used to connect and query using your normal tools:
+
+<pre class="console">Data container 'flyway-container' created!
+-> Host=instances.spawn.cc;Port=xxxxx;Username=xxxx;Database=foobardb;Password=xxxxxxxxx</pre>
+
+You can retrieve these details at any time by running:
+
+<pre class="console"><span>&gt;</span> spawnctl get data-container flyway-container -o yaml</pre>
+
+Let's now jump into our new directory created from downloading Flyway:
+
+<pre class="console"><span>&gt;</span> cd flyway-{{ site.flywayVersion }}</pre>
+
+Configure Flyway by editing `/conf/flyway.conf` with your Spawn data container connection details, like this:
 
 ```properties
-flyway.url=jdbc:h2:file:./foobardb
-flyway.user=SA
-flyway.password=
+flyway.url=jdbc:postgresql://instances.spawn.cc:port/foobardb
+flyway.user=user
+flyway.password=password
 ```
 
 ## Creating the first migration

--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -93,8 +93,8 @@ Successfully applied 1 migration to schema "PUBLIC" (execution time 00:00.016s)<
 ## Summary
 
 In this brief tutorial we saw how to:
-- install the Flyway Command-line tool
-- configure it so it can talk to our database
+- install the Flyway Command-line tool and Spawn
+- configure it so it can talk to our Spawn database
 - write our first couple of migrations
 
 These migrations were then successfully found and executed.

--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -63,7 +63,7 @@ It's now time to execute Flyway to migrate your database:
 
 If all went well, you should see the following output:
 
-<pre class="console">Database: jdbc:h2:file:./foobardb (H2 1.4)
+<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:port/foobardb (PostgreSQL 11.0)
 Successfully validated 1 migration (execution time 00:00.008s)
 Creating Schema History table: "PUBLIC"."flyway_schema_history"
 Current version of schema "PUBLIC": << Empty Schema >>
@@ -84,7 +84,7 @@ and execute it by issuing:
 
 You now get:
 
-<pre class="console">Database: jdbc:h2:file:./foobardb (H2 1.4)
+<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:port/foobardb (PostgreSQL 11.0)
 Successfully validated 2 migrations (execution time 00:00.018s)
 Current version of schema "PUBLIC": 1
 Migrating schema "PUBLIC" to version 2 - Add people

--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -7,7 +7,7 @@ redirect_from: /getStarted/firststeps/commandline/
 # First Steps: Command-line
 
 This brief tutorial will teach **how to get up and running with the Flyway Command-line tool**. It will take you through the
-steps on how to configure it and how to write and execute your first few database migrations, using <a href="spawn.cc">Spawn</a> to provision a database instance without the need for installing any database engines onto your own machine.
+steps on how to configure it and how to write and execute your first few database migrations, using <a href="spawn.cc">Spawn</a> to provision a database instance without the need for installing any database engines onto your own machine. You can create MySQL, MSSQL and PostgreSQL databases with Spawn that will work with Flyway.
 
 This tutorial should take you about **10 minutes** to complete.
 
@@ -19,7 +19,7 @@ Install Spawn by visiting the <a href="https://www.spawn.cc/docs/getting-started
 
 ## Configuring Flyway
 
-To configure Flyway, we first need a database we can connect to. We’ll use Spawn to create your own, isolated database environment from which you can run migrations against. This will create you your first data container, which is your database instance:
+To configure Flyway, we first need a database we can connect to. We’ll use Spawn to create your own, isolated database environment from which you can run migrations against. This will create you your first data container, which is your database instance. Here we are specifying a PostgreSQL database but you can also specify `mysql:empty` or `mssql:empty`:
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container --image postgres:empty --name flyway-container</pre>
 

--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -39,9 +39,9 @@ Let's now jump into our new directory created from downloading Flyway:
 Configure Flyway by editing `/conf/flyway.conf` with your Spawn data container connection details, like this:
 
 ```properties
-flyway.url=jdbc:postgresql://instances.spawn.cc:port/foobardb
-flyway.user=user
-flyway.password=password
+flyway.url=jdbc:postgresql://instances.spawn.cc:<Port>/foobardb
+flyway.user=<User>
+flyway.password=<Password>
 ```
 
 ## Creating the first migration
@@ -63,7 +63,7 @@ It's now time to execute Flyway to migrate your database:
 
 If all went well, you should see the following output:
 
-<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:port/foobardb (PostgreSQL 11.0)
+<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:<Port>/foobardb (PostgreSQL 11.0)
 Successfully validated 1 migration (execution time 00:00.008s)
 Creating Schema History table: "PUBLIC"."flyway_schema_history"
 Current version of schema "PUBLIC": << Empty Schema >>
@@ -84,7 +84,7 @@ and execute it by issuing:
 
 You now get:
 
-<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:port/foobardb (PostgreSQL 11.0)
+<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:<Port>/foobardb (PostgreSQL 11.0)
 Successfully validated 2 migrations (execution time 00:00.018s)
 Current version of schema "PUBLIC": 1
 Migrating schema "PUBLIC" to version 2 - Add people

--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -90,6 +90,12 @@ Current version of schema "PUBLIC": 1
 Migrating schema "PUBLIC" to version 2 - Add people
 Successfully applied 1 migration to schema "PUBLIC" (execution time 00:00.016s)</pre>
 
+Any time you want to reset your database back to it's original state, in this case an empty instance, you can run a reset command on your Spawn data container:
+
+<pre class="console"><span>&gt;</span> spawnctl reset data-container flyway-container</pre>
+
+You can then re-run migrate on your database.
+
 ## Summary
 
 In this brief tutorial we saw how to:

--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -7,17 +7,19 @@ redirect_from: /getStarted/firststeps/commandline/
 # First Steps: Command-line
 
 This brief tutorial will teach **how to get up and running with the Flyway Command-line tool**. It will take you through the
-steps on how to configure it and how to write and execute your first few database migrations.
+steps on how to configure it and how to write and execute your first few database migrations, using <a href="spawn.cc">Spawn</a> to provision a database instance without the need for installing any database engines onto your own machine.
 
-This tutorial should take you about **5 minutes** to complete.
+This tutorial should take you about **10 minutes** to complete.
 
-## Downloading and extracting Flyway
+## Prerequisites
 
 Start by <a href="/download">downloading the Flyway Command-line Tool</a> for your platform and extract it.
 
 Let's jump into our new directory:
 
 <pre class="console"><span>&gt;</span> cd flyway-{{ site.flywayVersion }}</pre>
+
+Install Spawn by visiting the <a href="https://www.spawn.cc/docs/getting-started.html">getting started documentation</a> and following the installation steps.
 
 ## Configuring Flyway
 


### PR DESCRIPTION
This PR alters the getting started experience, by integrating Spawn into the set-up guide, and pointing `flyway.conf` to the Spawn database.

I've gone through the steps myself to check that it makes sense/works.