### PR TITLE
Rename Spawn images in the getting started docs

### DIFF
--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -27,7 +27,10 @@ To configure Flyway, we first need a database we can connect to. We’ll use Spa
 from which you can run migrations against. This will create you your first data container, which is your database instance. Here we
 are specifying a PostgreSQL database but you can also specify `mysql:flyway-getting-started` or `mssql:flyway-getting-started`:
 
-<pre class="console"><span>&gt;</span> spawnctl create data-container --image postgres:flyway-getting-started --name flyway-container</pre>
+<pre class="console"><span>&gt;</span> spawnctl create data-container \
+  --image postgres:flyway-getting-started \
+  --name flyway-container \
+  --lifetime 24h</pre>
 
 This will return connection string details which is used to connect and query using your normal tools:
 

--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -25,9 +25,9 @@ the installation steps.
 
 To configure Flyway, we first need a database we can connect to. We’ll use Spawn to create your own, isolated database environment
 from which you can run migrations against. This will create you your first data container, which is your database instance. Here we
-are specifying a PostgreSQL database but you can also specify `mysql:empty` or `mssql:empty`:
+are specifying a PostgreSQL database but you can also specify `mysql:flyway-getting-started` or `mssql:flyway-getting-started`:
 
-<pre class="console"><span>&gt;</span> spawnctl create data-container --image postgres:empty --name flyway-container</pre>
+<pre class="console"><span>&gt;</span> spawnctl create data-container --image postgres:flyway-getting-started --name flyway-container</pre>
 
 This will return connection string details which is used to connect and query using your normal tools:
 


### PR DESCRIPTION
We've altered our public data images name in Spawn, so this updates the document to reference that.
Also we're adding a lifetime flag on the containers created, so databases are cleaned up automatically after 24 hours now.