### PR TITLE
Move pages under Advanced to top-level Tutorial section

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -64,9 +64,6 @@ title: Documentation
                             <summary class="nav-header">Advanced</summary>
 
                             <ul class="nav nav-pills nav-stacked">
-                                <li
-                                {% if page.menu == 'gs_migrationtesting' %} class="nav--vertical__active" {% endif %}>
-                                <a href="/documentation/getstarted/advanced/migrationtesting">Migration testing</a></li>
                             </ul>
                         </details>
                     </details>
@@ -300,6 +297,10 @@ title: Documentation
                             <li
                             {% if page.menu == 'tut_dryruns' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/tutorials/dryruns">Dry Runs</a></li>
+
+                            <li
+                            {% if page.menu == 'gs_migrationtesting' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/tutorials/migrationtesting">Migration testing</a></li>
                         </ul>
                     </details>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -65,10 +65,6 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.menu == 'gs_callbacks' %} class="nav--vertical__active" {% endif %}>
-                                <a href="/documentation/getstarted/advanced/callbacks">Callbacks</a></li>
-
-                                <li
                                 {% if page.menu == 'gs_erroroverrides' %} class="nav--vertical__active" {% endif %}>
                                 <a href="/documentation/getstarted/advanced/erroroverrides">Error Overrides</a></li>
 
@@ -300,6 +296,10 @@ title: Documentation
                             <li
                             {% if page.menu == 'java' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/tutorials/java">Java-based migrations</a></li>
+
+                            <li
+                            {% if page.menu == 'tut_callbacks' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/tutorials/callbacks">Callbacks</a></li>
                         </ul>
                     </details>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -65,10 +65,6 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.menu == 'gs_erroroverrides' %} class="nav--vertical__active" {% endif %}>
-                                <a href="/documentation/getstarted/advanced/erroroverrides">Error Overrides</a></li>
-
-                                <li
                                 {% if page.menu == 'gs_dryruns' %} class="nav--vertical__active" {% endif %}>
                                 <a href="/documentation/getstarted/advanced/dryruns">Dry Runs</a></li>
 
@@ -300,6 +296,10 @@ title: Documentation
                             <li
                             {% if page.menu == 'tut_callbacks' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/tutorials/callbacks">Callbacks</a></li>
+
+                            <li
+                            {% if page.menu == 'tut_erroroverrides' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/tutorials/erroroverrides">Error Overrides</a></li>
                         </ul>
                     </details>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -65,10 +65,6 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.menu == 'undo' %} class="nav--vertical__active" {% endif %}>
-                                <a href="/documentation/getstarted/advanced/undo">Undo migrations</a></li>
-
-                                <li
                                 {% if page.menu == 'java' %} class="nav--vertical__active" {% endif %}>
                                 <a href="/documentation/getstarted/advanced/java">Java-based migrations</a></li>
 
@@ -300,6 +296,10 @@ title: Documentation
                             <li
                             {% if page.menu == 'repeatable' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/tutorials/repeatable">Repeatable migrations</a></li>
+
+                            <li
+                            {% if page.menu == 'undo' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/tutorials/undo">Undo migrations</a></li>
                         </ul>
                     </details>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -65,10 +65,6 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.menu == 'gs_dryruns' %} class="nav--vertical__active" {% endif %}>
-                                <a href="/documentation/getstarted/advanced/dryruns">Dry Runs</a></li>
-
-                                <li
                                 {% if page.menu == 'gs_migrationtesting' %} class="nav--vertical__active" {% endif %}>
                                 <a href="/documentation/getstarted/advanced/migrationtesting">Migration testing</a></li>
                             </ul>
@@ -300,6 +296,10 @@ title: Documentation
                             <li
                             {% if page.menu == 'tut_erroroverrides' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/tutorials/erroroverrides">Error Overrides</a></li>
+
+                            <li
+                            {% if page.menu == 'tut_dryruns' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/tutorials/dryruns">Dry Runs</a></li>
                         </ul>
                     </details>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -65,10 +65,6 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.menu == 'java' %} class="nav--vertical__active" {% endif %}>
-                                <a href="/documentation/getstarted/advanced/java">Java-based migrations</a></li>
-
-                                <li
                                 {% if page.menu == 'gs_callbacks' %} class="nav--vertical__active" {% endif %}>
                                 <a href="/documentation/getstarted/advanced/callbacks">Callbacks</a></li>
 
@@ -300,6 +296,10 @@ title: Documentation
                             <li
                             {% if page.menu == 'undo' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/tutorials/undo">Undo migrations</a></li>
+
+                            <li
+                            {% if page.menu == 'java' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/tutorials/java">Java-based migrations</a></li>
                         </ul>
                     </details>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -65,10 +65,6 @@ title: Documentation
 
                             <ul class="nav nav-pills nav-stacked">
                                 <li
-                                {% if page.menu == 'repeatable' %} class="nav--vertical__active" {% endif %}>
-                                <a href="/documentation/getstarted/advanced/repeatable">Repeatable migrations</a></li>
-
-                                <li
                                 {% if page.menu == 'undo' %} class="nav--vertical__active" {% endif %}>
                                 <a href="/documentation/getstarted/advanced/undo">Undo migrations</a></li>
 
@@ -299,6 +295,12 @@ title: Documentation
 
                     <details {% if page.url contains "documentation/tutorials" %} open class="nav--vertical__active-parent" {% endif %}>
                         <summary class="nav-header">Tutorials</summary>
+
+                        <ul class="nav nav-pills nav-stacked">
+                            <li
+                            {% if page.menu == 'repeatable' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/tutorials/repeatable">Repeatable migrations</a></li>
+                        </ul>
                     </details>
 
                     <details {% if page.url contains "documentation/configuration" %} open class="nav--vertical__active-parent" {% endif %}>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -299,7 +299,7 @@ title: Documentation
                             <a href="/documentation/tutorials/dryruns">Dry Runs</a></li>
 
                             <li
-                            {% if page.menu == 'gs_migrationtesting' %} class="nav--vertical__active" {% endif %}>
+                            {% if page.menu == 'migrationtesting' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/tutorials/migrationtesting">Migration testing</a></li>
                         </ul>
                     </details>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -59,13 +59,6 @@ title: Documentation
                                 <a href="/documentation/getstarted/firststeps/gradle">Gradle</a></li>
                             </ul>
                         </details>
-
-                        <details {% if page.url contains "documentation/getstarted/advanced" %} open class="nav--vertical__active-parent" {% endif %}>
-                            <summary class="nav-header">Advanced</summary>
-
-                            <ul class="nav nav-pills nav-stacked">
-                            </ul>
-                        </details>
                     </details>
 
                     <details {% if page.url contains "documentation/concepts" %} open class="nav--vertical__active-parent" {% endif %}>

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -297,6 +297,10 @@ title: Documentation
                         </ul>
                     </details>
 
+                    <details {% if page.url contains "documentation/tutorials" %} open class="nav--vertical__active-parent" {% endif %}>
+                        <summary class="nav-header">Tutorials</summary>
+                    </details>
+
                     <details {% if page.url contains "documentation/configuration" %} open class="nav--vertical__active-parent" {% endif %}>
                         <summary class="nav-header">Configuration</summary>
 

--- a/documentation/tutorials/callbacks.md
+++ b/documentation/tutorials/callbacks.md
@@ -1,10 +1,11 @@
 ---
 layout: documentation
-menu: gs_callbacks
+menu: tut_callbacks
 subtitle: 'Tutorial: Callbacks'
 redirect_from:
 - /getStarted/callbacks/
 - /documentation/getstarted/callbacks/
+- /documentation/getstarted/advanced/callbacks/
 ---
 # Tutorial: Callbacks
 

--- a/documentation/tutorials/dryruns.md
+++ b/documentation/tutorials/dryruns.md
@@ -1,8 +1,10 @@
 ---
 layout: documentation
-menu: gs_dryruns
+menu: tut_dryruns
 subtitle: 'Tutorial: Dry Runs'
-redirect_from: /getStarted/dryruns/
+redirect_from: 
+- /getStarted/dryruns/
+- /documentation/getstarted/advanced/dryruns/
 ---
 # Tutorial: Dry Runs
 {% include teams.html %}

--- a/documentation/tutorials/erroroverrides.md
+++ b/documentation/tutorials/erroroverrides.md
@@ -1,10 +1,11 @@
 ---
 layout: documentation
-menu: gs_erroroverrides
+menu: tut_erroroverrides
 subtitle: 'Tutorial: Error Overrides'
 redirect_from:
 - /getStarted/erroroverrides/
 - /documentation/getstarted/errorhandlers/
+- /documentation/getstarted/advanced/erroroverrides/
 ---
 # Tutorial: Error Overrides
 {% include teams.html %}

--- a/documentation/tutorials/java.md
+++ b/documentation/tutorials/java.md
@@ -5,6 +5,7 @@ subtitle: 'Tutorial: Java-based Migrations'
 redirect_from:
 - /getStarted/java/
 - /documentation/getstarted/java/
+- /documentation/getstarted/advanced/java/
 ---
 # Tutorial: Java-based Migrations
 

--- a/documentation/tutorials/migrationtesting.md
+++ b/documentation/tutorials/migrationtesting.md
@@ -2,6 +2,7 @@
 layout: documentation
 menu: migrationtesting
 subtitle: 'Tutorial: Testing Flyway migrations in a CI pipeline'
+redirect_from: /documentation/getstarted/advanced/migrationtesting/
 ---
 # Tutorial: Testing Flyway migrations in a CI pipeline
 

--- a/documentation/tutorials/repeatable.md
+++ b/documentation/tutorials/repeatable.md
@@ -5,6 +5,7 @@ subtitle: 'Tutorial: Repeatable Migrations'
 redirect_from:
 - /getStarted/repeatable/
 - /documentation/getstarted/repeatable/
+- /documentation/getstarted/advanced/repeatable/
 ---
 # Tutorial: Repeatable Migrations
 

--- a/documentation/tutorials/undo.md
+++ b/documentation/tutorials/undo.md
@@ -5,6 +5,7 @@ subtitle: 'Tutorial: Undo Migrations'
 redirect_from:
 - /getStarted/undo/
 - /documentation/getstarted/undo/
+- /documentation/getstarted/advanced/undo/
 ---
 # Tutorial: Undo Migrations
 {% include teams.html %}


### PR DESCRIPTION
This surfaces the tutorials underneath Getting Started -> Advanced section on the Flyway site.