### PR TITLE
Adds Support Levels to database docs

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -730,6 +730,10 @@ title: Documentation
                             <li
                             {% if page.menu == 'faq' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/learnmore/faq">FAQ</a></li>
+
+                            <li
+                            {% if page.menu == 'Database Support Levels' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/learnmore/database-support">Database Support Levels</a></li>
                         </ul>
                     </details>
 

--- a/documentation/database/aurora-mysql.md
+++ b/documentation/database/aurora-mysql.md
@@ -10,6 +10,25 @@ subtitle: Aurora MySQL
 - `5.7`
 - `5.6` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Drivers
 
 <table class="table">

--- a/documentation/database/aurora-mysql.md
+++ b/documentation/database/aurora-mysql.md
@@ -27,7 +27,7 @@ subtitle: Aurora MySQL
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Drivers
 

--- a/documentation/database/aurora-postgresql.md
+++ b/documentation/database/aurora-postgresql.md
@@ -28,7 +28,7 @@ subtitle: Aurora PostgreSQL
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/aurora-postgresql.md
+++ b/documentation/database/aurora-postgresql.md
@@ -11,6 +11,25 @@ subtitle: Aurora PostgreSQL
 - `10.x`
 - `9.6`
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/azuresynapse.md
+++ b/documentation/database/azuresynapse.md
@@ -9,6 +9,25 @@ subtitle: Azure Synapse
 
 - `Latest`
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 <table class="table">
 <tr>

--- a/documentation/database/azuresynapse.md
+++ b/documentation/database/azuresynapse.md
@@ -26,7 +26,7 @@ subtitle: Azure Synapse
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 <table class="table">

--- a/documentation/database/cockroachdb.md
+++ b/documentation/database/cockroachdb.md
@@ -32,7 +32,7 @@ subtitle: CockroachDB
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/cockroachdb.md
+++ b/documentation/database/cockroachdb.md
@@ -15,6 +15,25 @@ subtitle: CockroachDB
 - `2.0`
 - `1.1`
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/db2.md
+++ b/documentation/database/db2.md
@@ -35,7 +35,7 @@ subtitle: DB2
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/db2.md
+++ b/documentation/database/db2.md
@@ -18,6 +18,24 @@ subtitle: DB2
 - `9.8` {% include teams.html %}
 - `9.7` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/derby.md
+++ b/documentation/database/derby.md
@@ -30,7 +30,7 @@ subtitle: Derby
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/derby.md
+++ b/documentation/database/derby.md
@@ -13,6 +13,25 @@ subtitle: Derby
 - `10.12` {% include teams.html %}
 - `10.11` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅ (see notes below)</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/firebird.md
+++ b/documentation/database/firebird.md
@@ -27,7 +27,7 @@ subtitle: Firebird
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/firebird.md
+++ b/documentation/database/firebird.md
@@ -10,6 +10,25 @@ subtitle: Firebird
 - `4.0`
 - `3.0`
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/h2.md
+++ b/documentation/database/h2.md
@@ -11,6 +11,25 @@ subtitle: H2
 - `1.3` {% include teams.html %}
 - `1.2` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/h2.md
+++ b/documentation/database/h2.md
@@ -28,7 +28,7 @@ subtitle: H2
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/hsqldb.md
+++ b/documentation/database/hsqldb.md
@@ -30,7 +30,7 @@ subtitle: HSQLDB
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/hsqldb.md
+++ b/documentation/database/hsqldb.md
@@ -13,6 +13,25 @@ subtitle: HSQLDB
 - `2.0` {% include teams.html %}
 - `1.8` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/informix.md
+++ b/documentation/database/informix.md
@@ -26,7 +26,7 @@ subtitle: Informix
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Drivers
 

--- a/documentation/database/informix.md
+++ b/documentation/database/informix.md
@@ -9,6 +9,25 @@ subtitle: Informix
 
 - `12.10`
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Drivers
 
 <table class="table">

--- a/documentation/database/mariadb.md
+++ b/documentation/database/mariadb.md
@@ -17,6 +17,24 @@ subtitle: MariaDB
 - `5.2` {% include teams.html %}
 - `5.1` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/mariadb.md
+++ b/documentation/database/mariadb.md
@@ -34,7 +34,7 @@ subtitle: MariaDB
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/mysql.md
+++ b/documentation/database/mysql.md
@@ -13,6 +13,25 @@ subtitle: MySQL
 - `5.5` {% include teams.html %}
 - `5.1` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Drivers
 
 <table class="table">

--- a/documentation/database/mysql.md
+++ b/documentation/database/mysql.md
@@ -30,7 +30,7 @@ subtitle: MySQL
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Drivers
 

--- a/documentation/database/oracle.md
+++ b/documentation/database/oracle.md
@@ -18,6 +18,25 @@ subtitle: Oracle
 
 All editions are supported, including XE.
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/oracle.md
+++ b/documentation/database/oracle.md
@@ -35,7 +35,7 @@ All editions are supported, including XE.
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/postgresql.md
+++ b/documentation/database/postgresql.md
@@ -19,6 +19,25 @@ subtitle: PostgreSQL
 - `9.1` {% include teams.html %}
 - `9.0` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/postgresql.md
+++ b/documentation/database/postgresql.md
@@ -36,7 +36,7 @@ subtitle: PostgreSQL
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/redshift.md
+++ b/documentation/database/redshift.md
@@ -5,6 +5,25 @@ subtitle: Redshift
 ---
 # Redshift
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/redshift.md
+++ b/documentation/database/redshift.md
@@ -22,7 +22,7 @@ subtitle: Redshift
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/saphana.md
+++ b/documentation/database/saphana.md
@@ -31,7 +31,7 @@ subtitle: SAP HANA
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/saphana.md
+++ b/documentation/database/saphana.md
@@ -14,6 +14,25 @@ subtitle: SAP HANA
 
 - `4.0`
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/snowflake.md
+++ b/documentation/database/snowflake.md
@@ -28,7 +28,7 @@ subtitle: Snowflake
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Drivers
 

--- a/documentation/database/snowflake.md
+++ b/documentation/database/snowflake.md
@@ -11,6 +11,25 @@ subtitle: Snowflake
 - `4.x` versions up to 4.2
 - `3.50` and later `3.x` versions
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Drivers
 
 <table class="table">

--- a/documentation/database/sqlite.md
+++ b/documentation/database/sqlite.md
@@ -26,7 +26,7 @@ subtitle: SQLite
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Drivers
 

--- a/documentation/database/sqlite.md
+++ b/documentation/database/sqlite.md
@@ -9,6 +9,25 @@ subtitle: SQLite
 
 - `3.7` and later `3.x` versions
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Drivers
 
 <table class="table">

--- a/documentation/database/sqlserver.md
+++ b/documentation/database/sqlserver.md
@@ -32,7 +32,7 @@ subtitle: SQL Server
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 

--- a/documentation/database/sqlserver.md
+++ b/documentation/database/sqlserver.md
@@ -15,6 +15,25 @@ subtitle: SQL Server
 - `2008 R2` {% include teams.html %}
 - `2008` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 
 <table class="table">

--- a/documentation/database/sybasease.md
+++ b/documentation/database/sybasease.md
@@ -29,7 +29,7 @@ subtitle: Sybase ASE
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Drivers
 

--- a/documentation/database/sybasease.md
+++ b/documentation/database/sybasease.md
@@ -12,6 +12,25 @@ subtitle: Sybase ASE
 - `16.0` {% include teams.html %}
 - `15.7` {% include teams.html %}
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Drivers
 
 <table class="table">

--- a/documentation/database/testcontainers.md
+++ b/documentation/database/testcontainers.md
@@ -22,7 +22,7 @@ subtitle: TestContainers
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Driver
 <table class="table">

--- a/documentation/database/testcontainers.md
+++ b/documentation/database/testcontainers.md
@@ -5,6 +5,25 @@ subtitle: TestContainers
 ---
 # TestContainers
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Driver
 <table class="table">
 <tr>

--- a/documentation/database/xtradb.md
+++ b/documentation/database/xtradb.md
@@ -9,6 +9,25 @@ subtitle: Percona XtraDB Cluster
 
 - `5.7`
 
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+
 ## Drivers
 
 <table class="table">

--- a/documentation/database/xtradb.md
+++ b/documentation/database/xtradb.md
@@ -26,7 +26,7 @@ subtitle: Percona XtraDB Cluster
     </tr>
 </table>
 
-Support Level determines the degree of support available for this database ([learn more](https://www.flywaydb.org/documentation/learnmore/database-support)). 
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
 
 ## Drivers
 

--- a/documentation/learnmore/database-support.md
+++ b/documentation/learnmore/database-support.md
@@ -2,6 +2,5 @@
 layout: documentation
 menu: support levels
 subtitle: Database Support Levels
-redirect_from: /documentation/learnmore/database-support
 ---
 

--- a/documentation/learnmore/database-support.md
+++ b/documentation/learnmore/database-support.md
@@ -4,3 +4,53 @@ menu: support levels
 subtitle: Database Support Levels
 ---
 
+# Database Support Levels
+
+As Flyway grows, the core Flyway team adds support for more database engines. This page explains what "support" means, and provides a single lookup to see the degree of support you can get for your chosen engine. 
+
+## The Levels
+
+For each database Flyway works with, we publish a documentation page, like this one for [PostgreSQL](/documentation/database/postgresql). On these pages you'll see a list of "Supported Versions", along with "Support Level". For PostgreSQL, the Support Levels look like this:
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>✅ {% include teams.html %}</td>
+    </tr>
+</table>
+
+There are three levels of support; Compatible, Certified and Guaranteed. 
+
+### Compatible
+
+"Compatible" means that Flyway has been reported to work with this database engine. The report of compatability may have come from user producing a forked versison of Flyway, or has been connected using Flyway's database extension mechanism.
+
+When a database is listed as "Compatible" only, it is either a lower priority when dealing with GitHub Issues raised against it, or it is going through the Certification process. 
+
+### Certified
+
+"Certified" means that support for the database has been signed off by the core Flyway team. The database engine will work "out of the box" as part of the normal Flyway package. 
+
+The certification process involves the development of testing infrastructure, test development and real world testing. The process is most often done in conjunction with the creator(s) of those database engines. If you are a database vendor and are interested in having your database certified to work with Flyway, please contact us. 
+
+A database going through the certification process will be marked as "pending".
+
+When a database is listed as "Certified", priority for bug-fixing is increased. However, fixes are often dependent on community input and time-to-resolution cannot be guaranteed.
+
+### Guaranteed
+
+Guaranteed support is only available to Flyway Teams edition customers.
+
+"Guaranteed" means that support for the database is provided at the level outlined in the end-user license agreement, including priority bug-fixing and prioritised feature requests.
+
+You can upgrade to Flyway Teams at anytime by visiting [flywaydb.org/download](https://www.flyway.org/download) and purchasing a Flyway Teams license.
+
+

--- a/documentation/learnmore/database-support.md
+++ b/documentation/learnmore/database-support.md
@@ -1,0 +1,7 @@
+---
+layout: documentation
+menu: support levels
+subtitle: Database Support Levels
+redirect_from: /documentation/learnmore/database-support
+---
+


### PR DESCRIPTION
This PR is designed to help users understand the degree of support they can expect from Flyway for each database engine. It:
 
- Adds a Support Level section to each database-specific page:
![image](https://user-images.githubusercontent.com/13132227/117010333-9bb84d80-ace4-11eb-8b0a-3fbb03cd5639.png)
- Adds a page to explain the Support Levels