### PR TITLE
Cloud Spanner docs

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -696,6 +696,10 @@ title: Documentation
                             <li
                             {% if page.menu == 'firebird' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/database/firebird">Firebird</a></li>
+
+                            <li
+                            {% if page.menu == 'cloudspanner' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/database/cloud-spanner">Cloud Spanner</a></li>
                         </ul>
                     </details>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -698,7 +698,7 @@ title: Documentation
                             <a href="/documentation/database/firebird">Firebird</a></li>
 
                             <li
-                            {% if page.menu == 'cloudspanner' %} class="nav--vertical__active" {% endif %}>
+                            {% if page.menu == 'cloud-spanner' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/database/cloud-spanner">Cloud Spanner</a></li>
                         </ul>
                     </details>

--- a/documentation/database/cloud-spanner.md
+++ b/documentation/database/cloud-spanner.md
@@ -1,0 +1,39 @@
+---
+layout: documentation
+menu: cloud-spanner
+subtitle: Cloud Spanner
+---
+# Cloud Spanner
+
+## Supported Versions
+
+- `Latest`
+
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>⏳ Pending certification</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>❌</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)).
+
+## Using Flyway with Cloud Spanner
+
+Google Cloud Spanner is in the process of being certified. The process of certification involves getting real world usage feedback from beta users. 
+
+<strong>If you'd like to use Spanner and you are happy to provide feedback as we build support for this database, please complete the form below:</strong> 
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLSeeB1dMrvGApG-UWmRSMQjW0MkZe9dlurI3zy8bbvk6O61Q2Q/viewform?embedded=true" width="520" height="1000" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+
+


### PR DESCRIPTION
Adds a page under "supported databases" for Google Cloud Spanner.
- Includes a status on Support Level
- Includes a form to sign up to work with us to certify Spanner support.
- Technical documentation (driver, syntax, auth etc) will need to be added.

![image](https://user-images.githubusercontent.com/13132227/117111526-a7a51d80-ad7f-11eb-9b84-6e82d1214abc.png)

