### PR TITLE
fix broken link

### DIFF
--- a/documentation/learnmore/database-support.md
+++ b/documentation/learnmore/database-support.md
@@ -59,4 +59,4 @@ Guaranteed support is only available to Flyway Teams edition customers.
 
 "Guaranteed" means that support for the database is provided at the level outlined in the end-user license agreement, including priority bug-fixing and prioritised feature requests.
 
-**Ready for guaranteed database support?** You can upgrade to Flyway Teams at anytime by visiting [flywaydb.org/download](https://www.flyway.org/download) and purchasing a Flyway Teams license, or by emailing <a href="mailto:sales@flywaydb.org">sales@flywaydb.org</a>.
+**Ready for guaranteed database support?** You can upgrade to Flyway Teams at anytime by visiting [flywaydb.org/download](https://www.flywaydb.org/download) and purchasing a Flyway Teams license, or by emailing <a href="mailto:sales@flywaydb.org">sales@flywaydb.org</a>.


### PR DESCRIPTION
Minor PR to fix this broken link (`flyway.org` should be `flywaydb.org`)
![image](https://user-images.githubusercontent.com/13132227/121369804-16a00400-c934-11eb-9479-8110c95ba3d9.png)
 