### PR TITLE
Add TimescaleDB

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -713,6 +713,9 @@ title: Documentation
                             {% if page.menu == 'testcontainers' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/database/testcontainers">TestContainers</a></li>
 
+                            <li
+                                {% if page.menu == 'timescaledb' %} class="nav--vertical__active" {% endif %}>
+                            <a href="/documentation/database/timescaledb">TimescaleDB</a></li>
                         </ul>
                     </details>
 

--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -714,7 +714,7 @@ title: Documentation
                             <a href="/documentation/database/testcontainers">TestContainers</a></li>
 
                             <li
-                                {% if page.menu == 'timescaledb' %} class="nav--vertical__active" {% endif %}>
+                            {% if page.menu == 'timescaledb' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/database/timescaledb">TimescaleDB</a></li>
                         </ul>
                     </details>

--- a/documentation/database/aurora-postgresql.md
+++ b/documentation/database/aurora-postgresql.md
@@ -3,7 +3,7 @@ layout: documentation
 menu: aurora-postgresql
 subtitle: Aurora PostgreSQL
 ---
-# PostgreSQL
+# Aurora PostgreSQL
 
 ## Supported Versions
 

--- a/documentation/database/timescaledb.md
+++ b/documentation/database/timescaledb.md
@@ -1,0 +1,72 @@
+---
+layout: documentation
+menu: timescaledb
+subtitle: TimescaleDB
+---
+# TimescaleDB
+
+## Supported Versions
+
+- `12`
+- `11`
+
+## Support Level
+
+<table class="table">
+    <tr>
+        <th width="25%">Compatible</th>
+        <td>✅</td>
+    </tr>
+    <tr>
+        <th width="25%">Certified</th>
+        <td>❌</td>
+    </tr>
+    <tr>
+        <th width="25%">Guaranteed</th>
+        <td>❌</td>
+    </tr>
+</table>
+
+Support Level determines the degree of support available for this database ([learn more](/documentation/learnmore/database-support)). 
+
+## Driver
+
+<table class="table">
+<tr>
+<th>URL format</th>
+<td><code>jdbc:postgresql://<i>host</i>:<i>port</i>/<i>database</i></code></td>
+</tr>
+<tr>
+<th>SSL support</th>
+<td>Yes - add <code>?ssl=true</code></td>
+</tr>
+<tr>
+<th>Ships with Flyway Command-line</th>
+<td>Yes</td>
+</tr>
+<tr>
+<th>Maven Central coordinates</th>
+<td><code>org.postgresql:postgresql:42.2.14</code></td>
+</tr>
+<tr>
+<th>Supported versions</th>
+<td><code>9.3-1104-jdbc4</code> and later</td>
+</tr>
+<tr>
+<th>Default Java class</th>
+<td><code>org.postgresql.Driver</code></td>
+</tr>
+</table>
+
+## Notes
+
+TimescaleDB is an extension to PostgreSQL and Flyway usage is the same for the two databases. For more details, 
+please refer to the [PostgreSQL](/documentation/database/postgresql) page.
+
+## Limitations
+
+- AWS SecretsManager is not supported with TimescaleDB.
+
+<p class="next-steps">
+    <a class="btn btn-primary" href="/documentation/database/aurora-postgresql">Aurora PostgreSQL <i class="fa fa-arrow-right"></i></a>
+</p>

--- a/documentation/index.md
+++ b/documentation/index.md
@@ -55,7 +55,7 @@ title: Documentation
     <a href="/documentation/database/mariadb">MariaDB</a>,
     <a href="/documentation/database/xtradb">Percona XtraDB Cluster</a>,
     <a href="/documentation/database/testcontainers">TestContainers</a>,
-    <a href="/documentation/database/postgresql">PostgreSQL</a> (including Amazon RDS, Azure Database, Google Cloud SQL &amp; Heroku),
+    <a href="/documentation/database/postgresql">PostgreSQL</a> (including Amazon RDS, Azure Database, Google Cloud SQL, TimescaleDB &amp; Heroku),
     <a href="/documentation/database/aurora-postgresql">Aurora PostgreSQL</a>,
     <a href="/documentation/database/redshift">Redshift</a>,
     <a href="/documentation/database/cockroachdb">CockroachDB</a>,

--- a/documentation/v6/database/aurora-postgresql.md
+++ b/documentation/v6/database/aurora-postgresql.md
@@ -3,7 +3,7 @@ layout: v6/documentation
 menu: aurora-postgresql
 subtitle: Aurora PostgreSQL
 ---
-# PostgreSQL
+# Aurora PostgreSQL
 
 ## Supported Versions
 


### PR DESCRIPTION
TimescaleDB is essentially a Postgres clone and works exactly the same way. As people want the documentation clarified, I've added a page, plus sanity-checked by pulling a TimescaleDB image and running the tests. The only test that failed was SecretsManager, which failed with an access-denied - this might be my machine, or a more general problem, we can investigate if it ever gets asked for.