### PR TITLE
Clarify what Spawn is just before the tutorial summary

### DIFF
--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -103,6 +103,12 @@ reset command on your Spawn data container:
 
 You can then re-run `migrate` on your database.
 
+## Continue to use Spawn
+
+At the start of this tutorial you used [Spawn](https://spawn.cc) to provision a database to learn how Flyway works.
+
+[Spawn](https://spawn.cc) is a cloud-hosted database provisioning service provided by Redgate. You can continue to use it for development or CI workflows. Read more about the features and use cases on the [Spawn Website](https://spawn.cc).
+
 ## Summary
 
 In this brief tutorial we saw how to:


### PR DESCRIPTION
This adds a brief section just before the tutorial summary to explain what Spawn is.

This will clarify _what_ spawn was used for during the tutorial to hopefully make it clearer where the barriers live between Spawn + Flyway.