### PR TITLE
Update h2 to show v2 support

### DIFF
--- a/documentation/database/h2.md
+++ b/documentation/database/h2.md
@@ -7,6 +7,7 @@ subtitle: H2
 
 ## Supported Versions
 
+- `2.0`
 - `1.4`
 - `1.3` {% include teams.html %}
 - `1.2` {% include teams.html %}
@@ -43,7 +44,7 @@ Support Level determines the degree of support available for this database ([lea
 </tr>
 <tr>
 <th>Maven Central coordinates</th>
-<td><code>com.h2database:h2:1.4.197</code></td>
+<td><code>com.h2database:h2:1.4.200</code></td>
 </tr>
 <tr>
 <th>Supported versions</th>


### PR DESCRIPTION
The next release will support h2 v2 (which is still compile-it-yourself for now, but release coming up soon).
