### PR TITLE
Integrate Spawn into 'undo' and 'dry run' tutorials

### DIFF
--- a/documentation/tutorials/dryruns.md
+++ b/documentation/tutorials/dryruns.md
@@ -9,11 +9,47 @@ redirect_from:
 # Tutorial: Dry Runs
 {% include teams.html %}
 
-This tutorial assumes you have successfully completed the [**First Steps: Command-line**](/documentation/getstarted/firststeps/commandline)
-tutorial. **If you have not done so, please do so first.** This tutorial picks up where that one left off.
-
 This brief tutorial will teach **how to do Dry Runs**. It will take you through the
 steps on how to use them.
+
+## Setting up the database
+
+This tutorial picks up from where the [**First Steps: Command-line**](/documentation/getstarted/firststeps/commandline) tutorial left off.
+
+To get started quickly without having to run through that tutorial first, we will create a new [Spawn](https://spawn.cc) data container
+with the migrations from that tutorial already applied:
+
+```bash
+spawnctl create data-container -i postgres:flyway-getting-started-complete
+```
+
+Configure Flyway by editing `./flyway.conf` with your Spawn data container connection details, like this:
+
+```properties
+flyway.url=jdbc:postgresql://instances.spawn.cc:<Port>/foobardb
+flyway.user=<User>
+flyway.password=<Password>
+```
+
+Create a `./sql` directory and create the two migration scripts that have already been applied.
+The first file should be called `V1__Create_person_table.sql`:
+
+```sql
+create table PERSON (
+    ID int not null,
+    NAME varchar(100) not null
+);
+```
+
+and the second one called `V2__Add_people.sql`:
+
+```sql
+insert into PERSON (ID, NAME) values (1, 'Axel');
+insert into PERSON (ID, NAME) values (2, 'Mr. Foo');
+insert into PERSON (ID, NAME) values (3, 'Ms. Bar');
+```
+
+The database is now ready to go.
 
 ## Introduction
 

--- a/documentation/tutorials/dryruns.md
+++ b/documentation/tutorials/dryruns.md
@@ -86,7 +86,7 @@ This should give you the following status:
 
 Let's add a new migration for which we'll do a dry run at first.
 
-In the `/sql` directory, create a migration called `V3__Couple.sql`:
+In the `./sql` directory, create a migration called `V3__Couple.sql`:
 
 ```sql
 create table COUPLE (

--- a/documentation/tutorials/dryruns.md
+++ b/documentation/tutorials/dryruns.md
@@ -37,7 +37,7 @@ After having completed the [First Steps: Command-line](/documentation/getstarted
 
 This should give you the following status:
 
-<pre class="console">Database: jdbc:h2:file:./target/foobar (H2 1.4)
+<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:31585/ (PostgreSQL 11.0)
 
 +-----------+---------+---------------------+------+---------------------+---------+
 | Category  | Version | Description         | Type | Installed On        | State   |
@@ -117,7 +117,7 @@ Either one of these approaches yields the same result as you can see using:
 
 This should give you the following status:
 
-<pre class="console">Database: jdbc:h2:file:./target/foobar (H2 1.4)
+<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:31585/ (PostgreSQL 11.0)
 Schema version: 3
 
 +-----------+---------+---------------------+------+---------------------+---------+----------+

--- a/documentation/tutorials/undo.md
+++ b/documentation/tutorials/undo.md
@@ -29,8 +29,8 @@ After having completed the [First Steps: Command-line](/documentation/getstarted
 
 This should give you the following status:
 
-<pre class="console">Database: jdbc:h2:file:./foobardb (H2 1.4)
-                     
+<pre class="console">Database: jdbc:postgresql://instances.spawn.cc:31585/ (PostgreSQL 11.0)
+
 +-----------+---------+---------------------+------+---------------------+---------+----------+
 | Category  | Version | Description         | Type | Installed On        | State   | Undoable |
 +-----------+---------+---------------------+------+---------------------+---------+----------+
@@ -59,8 +59,8 @@ This is now the status
 
 <pre class="console"><span>flyway-{{ site.flywayVersion }}&gt;</span> flyway <strong>info</strong>
 
-Database: jdbc:h2:file:./foobardb (H2 1.4)
-                     
+Database: Database: jdbc:postgresql://instances.spawn.cc:31585/ (PostgreSQL 11.0)
+
 +-----------+---------+---------------------+------+---------------------+---------+----------+
 | Category  | Version | Description         | Type | Installed On        | State   | Undoable |
 +-----------+---------+---------------------+------+---------------------+---------+----------+
@@ -80,7 +80,7 @@ So go ahead and invoke
 
 This will give you the following result:
 
-<pre class="console">Database: jdbc:h2:file:./foobardb (H2 1.4)
+<pre class="console">Database: Database: jdbc:postgresql://instances.spawn.cc:31585/ (PostgreSQL 11.0)
 Current version of schema "PUBLIC": 2
 Undoing migration of schema "PUBLIC" to version 2 - Add people
 Successfully undid 1 migration to schema "PUBLIC" (execution time 00:00.030s)</pre>
@@ -89,8 +89,8 @@ And you can check that this is indeed the new status:
 
 <pre class="console"><span>flyway-{{ site.flywayVersion }}&gt;</span> flyway <strong>info</strong>
 
-Database: jdbc:h2:file:./foobardb (H2 1.4)
-                     
+Database: Database: jdbc:postgresql://instances.spawn.cc:31585/ (PostgreSQL 11.0)
+
 +-----------+---------+---------------------+----------+---------------------+---------+----------+
 | Category  | Version | Description         | Type     | Installed On        | State   | Undoable |
 +-----------+---------+---------------------+----------+---------------------+---------+----------+
@@ -106,7 +106,7 @@ We can now safely reapply it with
 
 <pre class="console"><span>flyway-{{ site.flywayVersion }}&gt;</span> flyway <strong>migrate</strong>
 
-Database: jdbc:h2:file:./foobardb (H2 1.4)
+Database: Database: jdbc:postgresql://instances.spawn.cc:31585/ (PostgreSQL 11.0)
 Successfully validated 5 migrations (execution time 00:00.020s)
 Current version of schema "PUBLIC": 1
 Migrating schema "PUBLIC" to version 2 - Add people
@@ -116,7 +116,7 @@ And the status is now
 
 <pre class="console"><span>flyway-{{ site.flywayVersion }}&gt;</span> flyway <strong>info</strong>
 
-Database: jdbc:h2:file:./foobardb (H2 1.4)
+Database: Database: jdbc:postgresql://instances.spawn.cc:31585/ (PostgreSQL 11.0)
 
 +-----------+---------+---------------------+----------+---------------------+---------+----------+
 | Category  | Version | Description         | Type     | Installed On        | State   | Undoable |

--- a/documentation/tutorials/undo.md
+++ b/documentation/tutorials/undo.md
@@ -10,11 +10,47 @@ redirect_from:
 # Tutorial: Undo Migrations
 {% include teams.html %}
 
-This tutorial assumes you have successfully completed the [**First Steps: Command-line**](/documentation/getstarted/firststeps/commandline)
-tutorial. **If you have not done so, please do so first.** This tutorial picks up where that one left off.
-
 This brief tutorial will teach **how to use undo migrations**. It will take you through the
 steps on how to create and use them.
+
+## Setting up the database
+
+This tutorial picks up from where the [**First Steps: Command-line**](/documentation/getstarted/firststeps/commandline) tutorial left off.
+
+To get started quickly without having to run through that tutorial first, we will create a new [Spawn](https://spawn.cc) data container
+with the migrations from that tutorial already applied:
+
+```bash
+spawnctl create data-container -i postgres:flyway-getting-started-complete
+```
+
+Configure Flyway by editing `./flyway.conf` with your Spawn data container connection details, like this:
+
+```properties
+flyway.url=jdbc:postgresql://instances.spawn.cc:<Port>/foobardb
+flyway.user=<User>
+flyway.password=<Password>
+```
+
+Create a `./sql` directory and create the two migration scripts that have already been applied.
+The first file should be called `V1__Create_person_table.sql`:
+
+```sql
+create table PERSON (
+    ID int not null,
+    NAME varchar(100) not null
+);
+```
+
+and the second one called `V2__Add_people.sql`:
+
+```sql
+insert into PERSON (ID, NAME) values (1, 'Axel');
+insert into PERSON (ID, NAME) values (2, 'Mr. Foo');
+insert into PERSON (ID, NAME) values (3, 'Ms. Bar');
+```
+
+The database is now ready to go.
 
 ## Introduction
 


### PR DESCRIPTION
Add a new section to the 'undo' and 'dry run' tutorial pages.

Previously, we'd assume that users would be in a position to continue on from the 'first steps - commandline' tutorial, ie that they would have the Spawn data container still running and be in  a position to run `flyway` commands against it.

Rather than make this assumption, the new section asks the user to create a fresh data container from an image that represents the final state of the 'first steps - commandline' tutorial.