### PR TITLE
Make some small changes to the undo, dryrun and batch tutorials

### DIFF
--- a/documentation/tutorials/batch.md
+++ b/documentation/tutorials/batch.md
@@ -22,7 +22,7 @@ We will use [Spawn](https://spawn.cc) to create a database for this tutorial. Ru
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container \
   --image postgres:flyway-getting-started \
-  --name flyway-container \
+  --name flyway-batch \
   --lifetime 24h</pre>
 
 This will return the connection string details which are used to connect and query using your normal tools:

--- a/documentation/tutorials/dryruns.md
+++ b/documentation/tutorials/dryruns.md
@@ -19,7 +19,10 @@ This tutorial picks up from where the [**First Steps: Command-line**](/documenta
 To get started quickly without having to run through that tutorial first, we will create a new [Spawn](https://spawn.cc) data container
 with the migrations from that tutorial already applied:
 
-<pre class="console"><span>&gt;</span> spawnctl create data-container -i postgres:flyway-getting-started-complete</pre>
+<pre class="console"><span>&gt;</span> spawnctl create data-container \
+  --image postgres:flyway-getting-started-complete \
+  --name flyway-dryrun \
+  --lifetime 24h</pre>
 
 Configure Flyway by editing `./flyway.conf` with your Spawn data container connection details, like this:
 

--- a/documentation/tutorials/dryruns.md
+++ b/documentation/tutorials/dryruns.md
@@ -24,6 +24,14 @@ with the migrations from that tutorial already applied:
   --name flyway-dryrun \
   --lifetime 24h</pre>
 
+The `flyway-getting-started-complete` image is available for other database engines besides `postgres`. Use:
+
+```bash
+$ spawnctl get data-images --public | grep flyway-getting-started-complete
+```
+
+to find them.
+
 Configure Flyway by editing `./flyway.conf` with your Spawn data container connection details, like this:
 
 ```properties

--- a/documentation/tutorials/undo.md
+++ b/documentation/tutorials/undo.md
@@ -25,6 +25,14 @@ with the migrations from that tutorial already applied:
   --name flyway-undo \
   --lifetime 24h</pre>
 
+The `flyway-getting-started-complete` image is available for other database engines besides `postgres`. Use:
+
+```bash
+$ spawnctl get data-images --public | grep flyway-getting-started-complete
+```
+
+to find them.
+
 Configure Flyway by editing `./flyway.conf` with your Spawn data container connection details, like this:
 
 ```properties

--- a/documentation/tutorials/undo.md
+++ b/documentation/tutorials/undo.md
@@ -20,7 +20,10 @@ This tutorial picks up from where the [**First Steps: Command-line**](/documenta
 To get started quickly without having to run through that tutorial first, we will create a new [Spawn](https://spawn.cc) data container
 with the migrations from that tutorial already applied:
 
-<pre class="console"><span>&gt;</span> spawnctl create data-container -i postgres:flyway-getting-started-complete</pre>
+<pre class="console"><span>&gt;</span> spawnctl create data-container \
+  --image postgres:flyway-getting-started-complete \
+  --name flyway-undo \
+  --lifetime 24h</pre>
 
 Configure Flyway by editing `./flyway.conf` with your Spawn data container connection details, like this:
 


### PR DESCRIPTION
Add names and lifetimes to the data containers created in the tutorials:

* Names so that we can identify users coming from these tutorials more easily.
* Lifetimes so we don't build up lots of these containers over time.
