### PR TITLE
Update the top Spawn links on docs pages to go to spawn on flyway docs

### DIFF
--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -8,7 +8,7 @@ redirect_from: /getStarted/firststeps/commandline/
 # First Steps: Command-line
 
 This brief tutorial will teach **how to get up and running with the Flyway Command-line tool**. It will take you through the
-steps on how to configure it and how to write and execute your first few database migrations, using [Spawn](https://spawn.cc/)
+steps on how to configure it and how to write and execute your first few database migrations, using [Spawn](/documentation/spawn){:target="_blank"}
 to provision a database instance without the need for installing any database engines onto your own machine. You can create MySQL,
 MSSQL and PostgreSQL databases with Spawn that will work with Flyway.
 
@@ -18,7 +18,7 @@ This tutorial should take you about **10 minutes** to complete.
 
 Start by [downloading the Flyway Command-line Tool](/download) for your platform and extract it.
 
-Install Spawn by visiting the [getting started documentation](https://www.spawn.cc/docs/getting-started.html) and following
+Install Spawn by visiting the [getting started documentation](/documentation/spawn/firststeps/installation){:target="_blank"} and following
 the installation steps.
 
 ## Configuring Flyway

--- a/documentation/learnmore/existing.md
+++ b/documentation/learnmore/existing.md
@@ -9,13 +9,13 @@ redirect_from: /documentation/existing/
 
 These are the steps to follow to successfully integrate Flyway into a project with existing databases.
 
-To guide you through the process, we'll show examples using [Spawn](https://spawn.cc) to quickly provision database instances that will represent our Development and Production environments.
+To guide you through the process, we'll show examples using [Spawn](/documentation/spawn){:target="_blank"} to quickly provision database instances that will represent our Development and Production environments.
 
 ## Prerequisites
 
 If you are new to Flyway, read through our [getting started](/documentation/getstarted/) section first.
 
-To follow along with the examples, [install Spawn](https://spawn.cc/docs/howto-installation) and run the following commands to create our Development and Production instances:
+To follow along with the examples, [install Spawn](/documentation/spawn/firststeps/installation){:target="_blank"} and run the following commands to create our Development and Production instances:
 
 <pre class="console">&gt; spawnctl create data-container \
   --image postgres:flyway-existing-database \

--- a/documentation/tutorials/batch.md
+++ b/documentation/tutorials/batch.md
@@ -18,7 +18,7 @@ This is particularly useful for very large SQL migrations composed of multiple M
 
 ## Setting up the database
 
-We will use [Spawn](https://spawn.cc) to create a database for this tutorial. Run the following command:
+We will use [Spawn](/documentation/spawn){:target="_blank"} to create a database for this tutorial. Run the following command:
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container \
   --image postgres:flyway-getting-started \

--- a/documentation/tutorials/dryruns.md
+++ b/documentation/tutorials/dryruns.md
@@ -16,7 +16,7 @@ steps on how to use them.
 
 This tutorial picks up from where the [**First Steps: Command-line**](/documentation/getstarted/firststeps/commandline) tutorial left off.
 
-To get started quickly without having to run through that tutorial first, we will create a new [Spawn](https://spawn.cc) data container
+To get started quickly without having to run through that tutorial first, we will create a new [Spawn](/documentation/spawn/){:target="_blank"} data container
 with the migrations from that tutorial already applied:
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container \

--- a/documentation/tutorials/migrationtesting.md
+++ b/documentation/tutorials/migrationtesting.md
@@ -6,13 +6,13 @@ redirect_from: /documentation/getstarted/advanced/migrationtesting/
 ---
 # Tutorial: Testing Flyway migrations in a CI pipeline
 
-This tutorial will guide you through the process of setting up Flyway migration tests in a CI pipeline using [Spawn](spawn.cc) to provision a database on the fly.
+This tutorial will guide you through the process of setting up Flyway migration tests in a CI pipeline using [Spawn](/documentation/spawn){:target="_blank"} to provision a database on the fly.
 
 This tutorial should take you about **20 minutes** to complete.
 
 ## Prerequisites
 
-Install Spawn by visiting the [getting started documentation](https://www.spawn.cc/docs/getting-started.html) and following the installation steps.
+Install Spawn by visiting the [getting started documentation](/documentation/spawn/firststeps/installation){:target="_blank"} and following the installation steps.
 
 This tutorial will assume you have a database with Flyway migrations already set up and commited to your own repository. Alternatively, follow along with the examples taken from [this demo repo](https://github.com/red-gate/flyway-spawn-demo), which you can fork and clone.
 

--- a/documentation/tutorials/undo.md
+++ b/documentation/tutorials/undo.md
@@ -17,7 +17,7 @@ steps on how to create and use them.
 
 This tutorial picks up from where the [**First Steps: Command-line**](/documentation/getstarted/firststeps/commandline) tutorial left off.
 
-To get started quickly without having to run through that tutorial first, we will create a new [Spawn](https://spawn.cc) data container
+To get started quickly without having to run through that tutorial first, we will create a new [Spawn](/documentation/spawn){:target="_blank"} data container
 with the migrations from that tutorial already applied:
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container \


### PR DESCRIPTION
Rather than linking out to the Spawn site in the various tutorials etc for Spawn/Spawn getting started, link to the Spawn overview/getting started section of the Flyway site