### PR TITLE
Introduce Recent highlights section

### DIFF
--- a/_includes/recent-highlights.html
+++ b/_includes/recent-highlights.html
@@ -2,52 +2,52 @@
   <tr>
     <td>Try Flyway Teams Edition with new schemas for 28 days - no sign up required</td>
     <td>
-      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/learnmore/upgradingToTeams?ref=release-notes' text='Learn more' %}
+      <a href="/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
+      {% include release-notes-button.html url='/documentation/learnmore/upgradingToTeams?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
   <tr>
     <td>Beta support for Google Cloud Spanner + Big Query</td>
     <td>
-      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/database/big-query?ref=release-notes' text='Go to Big Query Beta' %}<br/>
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/database/cloud-spanner?ref=release-notes' text='Go to Cloud Spanner Beta' %}
+      <a href="/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
+      {% include release-notes-button.html url='/documentation/database/big-query?ref=release-notes' text='Go to Big Query Beta' %}<br/>
+      {% include release-notes-button.html url='/documentation/database/cloud-spanner?ref=release-notes' text='Go to Cloud Spanner Beta' %}
     </td>
   </tr>
   <tr>
     <td>Define your own rules for the validate command</td>
     <td>
-      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.8.0">Since 7.8.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/ignoreMigrationPatterns?ref=release-notes' text='Learn more' %}
+      <a href="/documentation/learnmore/releaseNotes#7.8.0">Since 7.8.0</a><br />
+      {% include release-notes-button.html url='/documentation/configuration/parameters/ignoreMigrationPatterns?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
   <tr>
     <td>Conditionally execute scripts based on boolean expressions</td>
     <td>
-      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/tutorials/injectingEnvironments?ref=release-notes' text='Learn more' %}
+      <a href="/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
+      {% include release-notes-button.html url='/documentation/tutorials/injectingEnvironments?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
   <tr>
     <td>Run shell scripts as migrations - including Python, Bash, PowerShell, and more</td>
     <td>
-      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/concepts/migrations?ref=release-notes#script-migrations' text='Learn more' %}
+      <a href="/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
+      {% include release-notes-button.html url='/documentation/concepts/migrations?ref=release-notes#script-migrations' text='Learn more' %}
     </td>
     <td></td>
   </tr>
   <tr>
     <td>Skip executing the contents of scripts whilst still retaining the record in the schema history table - perfect for introducing manually applied scripts into version control, and more.</td>
     <td>
-      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/skipExecutingMigrations?ref=release-notes' text='Learn more' %}
+      <a href="/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
+      {% include release-notes-button.html url='/documentation/configuration/parameters/skipExecutingMigrations?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
   <tr>
     <td>Have complete control over which scripts are deployed with Cherry Pick. You can also control the order of script execution.</td>
     <td>
-      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/cherryPick?ref=release-notes' text='Learn more' %}
+      <a href="/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
+      {% include release-notes-button.html url='/documentation/configuration/parameters/cherryPick?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
 </table>

--- a/_includes/recent-highlights.html
+++ b/_includes/recent-highlights.html
@@ -1,0 +1,53 @@
+<table class="table table-striped">
+  <tr>
+    <td>Try Flyway Teams Edition with new schemas for 28 days - no sign up required</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/learnmore/upgradingToTeams?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Beta support for Google Cloud Spanner + Big Query</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/database/big-query?ref=release-notes' text='Go to Big Query Beta' %}<br/>
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/database/cloud-spanner?ref=release-notes' text='Go to Cloud Spanner Beta' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Define your own rules for the validate command</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.8.0">Since 7.8.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/ignoreMigrationPatterns?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Conditionally execute scripts based on boolean expressions</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/tutorials/injectingEnvironments?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Run shell scripts as migrations - including Python, Bash, PowerShell, and more</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/concepts/migrations?ref=release-notes#script-migrations' text='Learn more' %}
+    </td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Skip executing the contents of scripts whilst still retaining the record in the schema history table - perfect for introducing manually applied scripts into version control, and more.</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/skipExecutingMigrations?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Have complete control over which scripts are deployed with Cherry Pick. You can also control the order of script execution.</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/cherryPick?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+</table>

--- a/_includes/recent-highlights.html
+++ b/_includes/recent-highlights.html
@@ -2,14 +2,14 @@
   <tr>
     <td>Try Flyway Teams Edition with new schemas for 28 days - no sign up required</td>
     <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
+      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
       {% include release-notes-button.html url='https://flywaydb.org/documentation/learnmore/upgradingToTeams?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
   <tr>
     <td>Beta support for Google Cloud Spanner + Big Query</td>
     <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
+      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
       {% include release-notes-button.html url='https://flywaydb.org/documentation/database/big-query?ref=release-notes' text='Go to Big Query Beta' %}<br/>
       {% include release-notes-button.html url='https://flywaydb.org/documentation/database/cloud-spanner?ref=release-notes' text='Go to Cloud Spanner Beta' %}
     </td>
@@ -17,21 +17,21 @@
   <tr>
     <td>Define your own rules for the validate command</td>
     <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.8.0">Since 7.8.0</a><br />
+      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.8.0">Since 7.8.0</a><br />
       {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/ignoreMigrationPatterns?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
   <tr>
     <td>Conditionally execute scripts based on boolean expressions</td>
     <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
+      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
       {% include release-notes-button.html url='https://flywaydb.org/documentation/tutorials/injectingEnvironments?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
   <tr>
     <td>Run shell scripts as migrations - including Python, Bash, PowerShell, and more</td>
     <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
+      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
       {% include release-notes-button.html url='https://flywaydb.org/documentation/concepts/migrations?ref=release-notes#script-migrations' text='Learn more' %}
     </td>
     <td></td>
@@ -39,14 +39,14 @@
   <tr>
     <td>Skip executing the contents of scripts whilst still retaining the record in the schema history table - perfect for introducing manually applied scripts into version control, and more.</td>
     <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
+      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
       {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/skipExecutingMigrations?ref=release-notes' text='Learn more' %}
     </td>
   </tr>
   <tr>
     <td>Have complete control over which scripts are deployed with Cherry Pick. You can also control the order of script execution.</td>
     <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
+      <a href="https://flywaydb.org/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
       {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/cherryPick?ref=release-notes' text='Learn more' %}
     </td>
   </tr>

--- a/_includes/release-notes-button.html
+++ b/_includes/release-notes-button.html
@@ -1,0 +1,1 @@
+<a href="{{ include.url }}" class="label label-primary" title="{{ include.text }}">{{ include.text }} <i class="fa fa-arrow-right"></i></a>

--- a/documentation/configuration/secretsManagement.md
+++ b/documentation/configuration/secretsManagement.md
@@ -9,7 +9,7 @@ redirect_from: /documentation/awsSecretsManager/
 
 A problem that organizations often encounter is where to store and how to access sensitive data such as the credentials for connecting to a database or their Flyway license key.
 
-Flyway comes with support for the following secrets manegement solutions that enable you to successfully handle sensitive data:
+Flyway comes with support for the following secrets management solutions that enable you to successfully handle sensitive data:
 
 - [AWS Secrets Manager](/documentation/configuration/secretsManagement#aws-secrets-manager)
 - [Vault](/documentation/configuration/secretsManagement#hashicorp-vault)

--- a/documentation/learnmore/releaseNotes.html
+++ b/documentation/learnmore/releaseNotes.html
@@ -12,59 +12,9 @@ Here's an overview of the biggest changes to Flyway since 7.0.0.
 <br/>
 <br/>
 
-<table class="table table-striped">
-  <tr>
-    <td>Try Flyway Teams Edition with new schemas for 28 days (CLI only) - no sign up required</td>
-    <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/learnmore/upgradingToTeams?ref=release-notes' text='Learn more' %}
-    </td>
-  </tr>
-  <tr>
-    <td>Beta support for Google Cloud Spanner + Big Query</td>
-    <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/database/big-query?ref=release-notes' text='Go to Big Query Beta' %}<br/>
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/database/cloud-spanner?ref=release-notes' text='Go to Cloud Spanner Beta' %}
-    </td>
-  </tr>
-  <tr>
-    <td>Define your own rules for the validate command</td>
-    <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.8.0">Since 7.8.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/ignoreMigrationPatterns?ref=release-notes' text='Learn more' %}
-    </td>
-  </tr>
-  <tr>
-    <td>Conditionally execute scripts based on boolean expressions</td>
-    <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/tutorials/injectingEnvironments?ref=release-notes' text='Learn more' %}
-    </td>
-  </tr>
-  <tr>
-    <td>Run shell scripts as migrations - including Python, Bash, PowerShell, and more</td>
-    <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/concepts/migrations?ref=release-notes#script-migrations' text='Learn more' %}
-    </td>
-    <td></td>
-  </tr>
-  <tr>
-    <td>Skip executing the contents of scripts whilst still retaining the record in the schema history table - perfect for introducing manually applied scripts into version control, and more.</td>
-    <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/skipExecutingMigrations?ref=release-notes' text='Learn more' %}
-    </td>
-  </tr>
-  <tr>
-    <td>Have complete control over which scripts are deployed with Cherry Pick. You can also control the order of script execution.</td>
-    <td>
-      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
-      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/cherryPick?ref=release-notes' text='Learn more' %}
-    </td>
-  </tr>
-</table>
+{% include recent-highlights.html %}
+
+<h2>Full release notes</h2>
 
 <div class="release">
     <h2 id="7.12.1">Flyway 7.12.1 (2021-08-05)</h2>

--- a/documentation/learnmore/releaseNotes.html
+++ b/documentation/learnmore/releaseNotes.html
@@ -6,7 +6,65 @@ redirect_from: /documentation/releaseNotes/
 ---
 <h1>Release Notes</h1>
 
-<p>Thank you all for reporting all these issues and contributing fixes!</p>
+<h2>Recent highlights</h2>
+
+Here's an overview of the biggest changes to Flyway since 7.0.0.
+<br/>
+<br/>
+
+<table class="table table-striped">
+  <tr>
+    <td>Try Flyway Teams Edition with new schemas for 28 days (CLI only) - no sign up required</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/learnmore/upgradingToTeams?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Beta support for Google Cloud Spanner + Big Query</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.11.0">Since 7.11.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/database/big-query?ref=release-notes' text='Go to Big Query Beta' %}<br/>
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/database/cloud-spanner?ref=release-notes' text='Go to Cloud Spanner Beta' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Define your own rules for the validate command</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.8.0">Since 7.8.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/ignoreMigrationPatterns?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Conditionally execute scripts based on boolean expressions</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/tutorials/injectingEnvironments?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Run shell scripts as migrations - including Python, Bash, PowerShell, and more</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.3.0">Since 7.3.0</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/concepts/migrations?ref=release-notes#script-migrations' text='Learn more' %}
+    </td>
+    <td></td>
+  </tr>
+  <tr>
+    <td>Skip executing the contents of scripts whilst still retaining the record in the schema history table - perfect for introducing manually applied scripts into version control, and more.</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/skipExecutingMigrations?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+  <tr>
+    <td>Have complete control over which scripts are deployed with Cherry Pick. You can also control the order of script execution.</td>
+    <td>
+      <a href="http://localhost:4000/documentation/learnmore/releaseNotes#7.0.0-beta1">Since 7.0.0-beta1</a><br />
+      {% include release-notes-button.html url='https://flywaydb.org/documentation/configuration/parameters/cherryPick?ref=release-notes' text='Learn more' %}
+    </td>
+  </tr>
+</table>
 
 <div class="release">
     <h2 id="7.12.1">Flyway 7.12.1 (2021-08-05)</h2>

--- a/documentation/learnmore/staying-up-to-date.md
+++ b/documentation/learnmore/staying-up-to-date.md
@@ -6,7 +6,19 @@ subtitle: Staying Up To Date
 
 # Staying up to date
 
-It's important to keep your Flyway installation up to date. Flyway is regularly updated with bugfixes and quality of life improvements.
+It's important to keep your Flyway installation up to date. Flyway is regularly updated with bugfixes and quality of life improvements.<br/>
+
+<h2>Recent highlights</h2>
+
+Here's an overview of the biggest changes to Flyway since 7.0.0.
+<br/>
+<br/>
+
+{% include recent-highlights.html %}
+
+<a href="https://flywaydb.org/documentation/learnmore/releaseNotes?ref=staying-up-to-date">
+  <button class="btn btn-primary">Go to full release notes</button>
+</a>
 
 ## Download the latest version
 

--- a/documentation/learnmore/staying-up-to-date.md
+++ b/documentation/learnmore/staying-up-to-date.md
@@ -16,7 +16,7 @@ Here's an overview of the biggest changes to Flyway since 7.0.0.
 
 {% include recent-highlights.html %}
 
-<a href="https://flywaydb.org/documentation/learnmore/releaseNotes?ref=staying-up-to-date">
+<a href="/documentation/learnmore/releaseNotes?ref=staying-up-to-date">
   <button class="btn btn-primary">Go to full release notes</button>
 </a>
 

--- a/documentation/learnmore/staying-up-to-date.md
+++ b/documentation/learnmore/staying-up-to-date.md
@@ -8,7 +8,7 @@ subtitle: Staying Up To Date
 
 It's important to keep your Flyway installation up to date. Flyway is regularly updated with bugfixes and quality of life improvements.<br/>
 
-<h2>Recent highlights</h2>
+## Recent highlights
 
 Here's an overview of the biggest changes to Flyway since 7.0.0.
 <br/>


### PR DESCRIPTION
Add a 'recent highlights' section to the release notes + staying up to date page.

This highlights the biggest changes made since V7. The intention is to clearly explain the value of new things delivered over the past year or so, which should help users who are lagging behind decide whether they'd like to upgrade.

![image](https://user-images.githubusercontent.com/20282448/128496022-75278873-baca-440a-9e33-9f82f5b4464e.png)

I recommend you try this yourself when reviewing.