### PR TITLE
Update spawn public image names ahead of rename

### DIFF
--- a/_includes/spawn-sampledatabases.html
+++ b/_includes/spawn-sampledatabases.html
@@ -22,7 +22,7 @@
 
                 <pre
                     class="console"
-                ><span>&gt;</span> spawnctl create data-container --image pagila:v11 --name spawn-tutorial --lifetime 1h</pre>
+                ><span>&gt;</span> spawnctl create data-container --image postgres-pagila:v11.0 --name spawn-tutorial --lifetime 1h</pre>
 
                 <div class="well well-small">
                     <strong>Note:</strong> The `--name` flag is optional. If you
@@ -86,7 +86,7 @@ ID    Name           Revision Status     Engine            CreatedAt
 
                 <pre
                     class="console"
-                ><span>&gt;</span> spawnctl create data-container --image sakila:v5.7 --name spawn-tutorial --lifetime 1h</pre>
+                ><span>&gt;</span> spawnctl create data-container --image mysql-sakila:v5.7 --name spawn-tutorial --lifetime 1h</pre>
 
                 <div class="well well-small">
                     <strong>Note:</strong> The `--name` flag is optional. If you
@@ -156,7 +156,7 @@ ID    Name           Revision Status     Engine            CreatedAt
 
                 <pre
                     class="console"
-                ><span>&gt;</span> spawnctl create data-container --image wide-world-importers:2017 --name spawn-tutorial --lifetime 1h</pre>
+                ><span>&gt;</span> spawnctl create data-container --image mssql-wideworldimporters:v2017 --name spawn-tutorial --lifetime 1h</pre>
 
                 <div class="well well-small">
                     <strong>Note:</strong> The `--name` flag is optional. If you

--- a/documentation/getstarted/firststeps/commandline.md
+++ b/documentation/getstarted/firststeps/commandline.md
@@ -25,10 +25,10 @@ the installation steps.
 
 To configure Flyway, we first need a database we can connect to. We’ll use Spawn to create your own, isolated database environment
 from which you can run migrations against. This will create you your first data container, which is your database instance. Here we
-are specifying a PostgreSQL database but you can also specify `mysql:flyway-getting-started` or `mssql:flyway-getting-started`:
+are specifying a PostgreSQL database but you can also specify `mysql-flyway-getting-started` or `mssql-flyway-getting-started`:
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container \
-  --image postgres:flyway-getting-started \
+  --image postgres-flyway-getting-started \
   --name flyway-container \
   --lifetime 24h</pre>
 

--- a/documentation/learnmore/existing.md
+++ b/documentation/learnmore/existing.md
@@ -18,12 +18,12 @@ If you are new to Flyway, read through our [getting started](/documentation/gets
 To follow along with the examples, [install Spawn](/documentation/spawn/firststeps/installation){:target="_blank"} and run the following commands to create our Development and Production instances:
 
 <pre class="console">&gt; spawnctl create data-container \
-  --image postgres:flyway-existing-database \
+  --image postgres-flyway-existing-database \
   --name flyway-container-dev \
   --lifetime 24h</pre>
 
 <pre class="console">&gt; spawnctl create data-container \
-  --image postgres:flyway-existing-database \
+  --image postgres-flyway-existing-database \
   --name flyway-container-prod \
   --lifetime 24h</pre>
 

--- a/documentation/tutorials/batch.md
+++ b/documentation/tutorials/batch.md
@@ -21,7 +21,7 @@ This is particularly useful for very large SQL migrations composed of multiple M
 We will use [Spawn](/documentation/spawn){:target="_blank"} to create a database for this tutorial. Run the following command:
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container \
-  --image postgres:flyway-getting-started \
+  --image postgres-flyway-getting-started \
   --name flyway-batch \
   --lifetime 24h</pre>
 

--- a/documentation/tutorials/dryruns.md
+++ b/documentation/tutorials/dryruns.md
@@ -20,7 +20,7 @@ To get started quickly without having to run through that tutorial first, we wil
 with the migrations from that tutorial already applied:
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container \
-  --image postgres:flyway-getting-started-complete \
+  --image postgres-flyway-getting-started-complete \
   --name flyway-dryrun \
   --lifetime 24h</pre>
 

--- a/documentation/tutorials/undo.md
+++ b/documentation/tutorials/undo.md
@@ -21,7 +21,7 @@ To get started quickly without having to run through that tutorial first, we wil
 with the migrations from that tutorial already applied:
 
 <pre class="console"><span>&gt;</span> spawnctl create data-container \
-  --image postgres:flyway-getting-started-complete \
+  --image postgres-flyway-getting-started-complete \
   --name flyway-undo \
   --lifetime 24h</pre>
 


### PR DESCRIPTION
We are renaming the spawn public images for consistency, this makes the flyway docs match