### PR TITLE
XtraDB 5.7 is only supported in Flyway Teams

### DIFF
--- a/documentation/database/xtradb.md
+++ b/documentation/database/xtradb.md
@@ -8,7 +8,7 @@ subtitle: Percona XtraDB Cluster
 ## Supported Versions
 
 - `8.0`
-- `5.7`
+- `5.7` {% include teams.html %}
 
 ## Support Level
 


### PR DESCRIPTION
We forgot to update the licensing requirements for Percona XtraDB when we released Flyway v8.

As MySQL 5.7 is now only supported in Flyway Teams, the same licensing requirement applies to XtraDB.

https://github.com/flyway/flyway/issues/3319
