### PR TITLE
Unify JavaScript across both parts of the website

### DIFF
--- a/_includes/downloadpopup.html
+++ b/_includes/downloadpopup.html
@@ -18,84 +18,81 @@
             </div>
             <div class="modal-body">
                 <form id="mktoForm_2997"></form>
-
-                <div class="privacy-notice">
-                    <p>We'll use your details to follow up with you about our products, solutions and events.</p>
-                    <p>To stop hearing from us, use the unsubscribe links in our emails, or let us know.</p>
-                    <p><a href="https://www.red-gate.com/website/legal" target="_blank" rel="noopener noreferrer">Read the full privacy notice.</a></p>
-                </div>
-
                 <p class="text-center" style="margin-top:10px;"><a class="skip-to-download" href="">Skip to download</a></p>
             </div>
         </div>
     </div>
 </div>
 
-<script src="//content.red-gate.com/js/forms2/js/forms2.min.js"></script>
 <script>
-    MktoForms2.loadForm("//content.red-gate.com", "808-ITG-788", 2997, function(marketoForm) {
-        marketoForm.onValidate(function(successful) {
-            if (!successful) {
-                marketoForm.submittable(false);
-            } else {
+    window.addEventListener('load', function(){
+        window.Redgate.Marketo.create({
+            formId: 2997,
+            callback: function(marketoForm) {
+                marketoForm.onValidate(function(successful) {
+                    if (!successful) {
+                        marketoForm.submittable(false);
+                    } else {
 
-                // Do some custom validation.
+                        // Do some custom validation.
 
-                // Get the fields and their values from the form.
-                var fields = marketoForm.vals();
+                        // Get the fields and their values from the form.
+                        var fields = marketoForm.vals();
 
-                // Custom object for storing info about the fail.
-                var fail = {
-                    isFail: false,
-                    message: '',
-                    element: null,
-                };
+                        // Custom object for storing info about the fail.
+                        var fail = {
+                            isFail: false,
+                            message: '',
+                            element: null,
+                        };
 
-                // Email validation.
-                if (typeof fields.Email !== 'undefined') {
+                        // Email validation.
+                        if (typeof fields.Email !== 'undefined') {
 
-                    // Email regex provided by https://regex101.com/r/L9Z2N0/1.
-                    // Check that the format is {something}@{something}.{something}.
-                    var emailRegex = /\S+@\S+\.\S+/;
+                            // Email regex provided by https://regex101.com/r/L9Z2N0/1.
+                            // Check that the format is {something}@{something}.{something}.
+                            var emailRegex = /\S+@\S+\.\S+/;
 
-                    if (emailRegex.test(fields.Email) === false) {
-                        fail.isFail = true;
-                        fail.message = 'Please enter a valid email address.';
-                        fail.element = marketoForm.getFormElem().find('input[name="Email"]');
+                            if (emailRegex.test(fields.Email) === false) {
+                                fail.isFail = true;
+                                fail.message = 'Please enter a valid email address.';
+                                fail.element = marketoForm.getFormElem().find('input[name="Email"]');
+                            }
+                        }
+
+                        // If form validation fails.
+                        if (fail.isFail) {
+
+                            // Stop the form from being submittable.
+                            marketoForm.submittable(false);
+
+                            // Show an error message against the invalid field.
+                            marketoForm.showErrorMessage(fail.message, fail.element);
+
+                            // Display the field as invalid using the Marketo class.
+                            fail.element.get(0).classList.add('mktoInvalid');
+                        } else {
+
+                            // All is good, continue as normal.
+                            marketoForm.submittable(true);
+                        }
                     }
-                }
+                });
 
-                // If form validation fails.
-                if (fail.isFail) {
+                // On successful submission of the form, redirect the user to the relevant download page.
+                marketoForm.onSuccess(function() {
+                    var downloadLink = document.querySelector('.download-email-modal .skip-to-download');
 
-                    // Stop the form from being submittable.
-                    marketoForm.submittable(false);
+                    if (downloadLink) {
+                        
+                        // Redirect the user to the download page.
+                        window.location.href = downloadLink;
 
-                    // Show an error message against the invalid field.
-                    marketoForm.showErrorMessage(fail.message, fail.element);
-
-                    // Display the field as invalid using the Marketo class.
-                    fail.element.get(0).classList.add('mktoInvalid');
-                } else {
-
-                    // All is good, continue as normal.
-                    marketoForm.submittable(true);
-                }
-            }
-        });
-
-        // On successful submission of the form, redirect the user to the relevant download page.
-        marketoForm.onSuccess(function() {
-            var downloadLink = document.querySelector('.download-email-modal .skip-to-download');
-
-            if (downloadLink) {
-                
-                // Redirect the user to the download page.
-                window.location.href = downloadLink;
-
-                // Return false to stop the form from reloading the page.
-                return false;
-            }
+                        // Return false to stop the form from reloading the page.
+                        return false;
+                    }
+                });
+            },
         });
     });
 

--- a/_includes/footer-javascript.html
+++ b/_includes/footer-javascript.html
@@ -1,0 +1,66 @@
+<script src="/assets/jquery-1.12.1/jquery-1.12.1.min.js" type="text/javascript"></script>
+<script src="https://flywaydb.org/wp-content/themes/flyway/global.js" type="text/javascript"></script>
+<script src="/assets/bootstrap-3.3.6-dist/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="/assets/prettify-20110601/prettify.js" type="text/javascript"></script>
+<script src="/assets/toc.js" type="text/javascript"></script>
+<script type="text/javascript">
+    $(function () {
+        prettyPrint();
+        $('#toc').toc({ listType: 'ul', noBackToTopLinks: true, showSpeed: 0, headers: 'h2, h3', title: '' });
+
+        $("h2[id],h3[id]").click(function () {
+            window.location.hash = $(this).attr("id");
+        });
+        $("tr[id]>td:first-child").click(function () {
+            window.location.hash = $(this).parent().attr("id");
+        });
+
+        $("a[href^=http]").each(function () {
+            if (this.href.indexOf(location.hostname) == -1) {
+                $(this).attr({
+                    target: "_blank"
+                });
+            }
+        });
+        $('.modal').on('shown.bs.modal', function() {
+            $(this).find('[autofocus]').focus();
+        });
+    });
+
+    if (navigator.platform.indexOf('Win') == -1) {
+        // Not windows
+        // Fix line continuation marks
+        $("pre.console").html(function () {
+            return $(this).html().replace(/\^\n/g, "\\\n");
+        });
+        // And prompt char
+        $("pre.console span").html(function () {
+            return $(this).html().replace("&gt;", "$");
+        });
+    }
+
+    function downloadDeferred(url) {
+        setTimeout(function () {
+            document.location.href = url;
+        }, 1000);
+    }
+
+    function hideAndDownload(id, url) {
+        $(id).modal('hide');
+
+        downloadDeferred("/download/thankyou?dl=" + url);
+    }
+
+    function hideAndSubmitTrialForm(formData) {
+        $.ajax({
+            type: "POST",
+            url: 'https://repo.flywaydb.org/license/trial',
+            data: formData
+        });
+
+        $('#flyway-trial-license-modal').modal('hide');
+    }
+</script>
+
+<!-- Place this tag right after the last button or just before your close body tag. -->
+<script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>

--- a/_includes/newsletter.html
+++ b/_includes/newsletter.html
@@ -2,69 +2,74 @@
 <!-- Begin Marketo Signup Form -->
 <div id="newsletter-sign-up">
     <h3 style="color: #888">{{ label }}</h3>
-    <script src="//content.red-gate.com/js/forms2/js/forms2.min.js"></script>
     <form id="mktoForm_2815"></form>
-    <script>MktoForms2.loadForm("//content.red-gate.com", "808-ITG-788", 2815, function(marketoForm) {
+    <script>
+        window.addEventListener('load', function() {
+            window.Redgate.Marketo.create({
+                formId: 2815,
+                callback: function(marketoForm) {
+                    // Set the email address field placeholder.
+                    var form = marketoForm.getFormElem().get(0);
+                    var input = form.querySelector('[name="Email"]').setAttribute('placeholder', 'Your email address');
 
-        // Set the email address field placeholder.
-        var form = marketoForm.getFormElem().get(0);
-        var input = form.querySelector('[name="Email"]').setAttribute('placeholder', 'Your email address');
+                    // On a successful submission, add a success message.
+                    marketoForm.onSuccess(function() {
+                        form.innerHTML = '<p>Thank you for subscribing to our newsletter. We\'ll be in touch soon.</p>';
+                        return false;
+                    });
 
-        // On a successful submission, add a success message.
-        marketoForm.onSuccess(function() {
-            form.innerHTML = '<p>Thank you for subscribing to our newsletter. We\'ll be in touch soon.</p>';
-            return false;
+                    marketoForm.onValidate(function(successful) {
+                        if (!successful) {
+                            marketoForm.submittable(false);
+                        } else {
+
+                            // Do some custom validation.
+
+                            // Get the fields and their values from the form.
+                            var fields = marketoForm.vals();
+
+                            // Custom object for storing info about the fail.
+                            var fail = {
+                                isFail: false,
+                                message: '',
+                                element: null,
+                            };
+
+                            // Email validation.
+                            if (typeof fields.Email !== 'undefined') {
+
+                                // Email regex provided by https://regex101.com/r/L9Z2N0/1.
+                                // Check that the format is {something}@{something}.{something}.
+                                var emailRegex = /\S+@\S+\.\S+/;
+
+                                if (emailRegex.test(fields.Email) === false) {
+                                    fail.isFail = true;
+                                    fail.message = 'Please enter a valid email address.';
+                                    fail.element = marketoForm.getFormElem().find('input[name="Email"]');
+                                }
+                            }
+
+                            // If form validation fails.
+                            if (fail.isFail) {
+
+                                // Stop the form from being submittable.
+                                marketoForm.submittable(false);
+
+                                // Show an error message against the invalid field.
+                                marketoForm.showErrorMessage(fail.message, fail.element);
+
+                                // Display the field as invalid using the Marketo class.
+                                fail.element.get(0).classList.add('mktoInvalid');
+                            } else {
+
+                                // All is good, continue as normal.
+                                marketoForm.submittable(true);
+                            }
+                        }
+                    });
+                },
+            });
         });
-
-        marketoForm.onValidate(function(successful) {
-            if (!successful) {
-                marketoForm.submittable(false);
-            } else {
-
-                // Do some custom validation.
-
-                // Get the fields and their values from the form.
-                var fields = marketoForm.vals();
-
-                // Custom object for storing info about the fail.
-                var fail = {
-                    isFail: false,
-                    message: '',
-                    element: null,
-                };
-
-                // Email validation.
-                if (typeof fields.Email !== 'undefined') {
-
-                    // Email regex provided by https://regex101.com/r/L9Z2N0/1.
-                    // Check that the format is {something}@{something}.{something}.
-                    var emailRegex = /\S+@\S+\.\S+/;
-
-                    if (emailRegex.test(fields.Email) === false) {
-                        fail.isFail = true;
-                        fail.message = 'Please enter a valid email address.';
-                        fail.element = marketoForm.getFormElem().find('input[name="Email"]');
-                    }
-                }
-
-                // If form validation fails.
-                if (fail.isFail) {
-
-                    // Stop the form from being submittable.
-                    marketoForm.submittable(false);
-
-                    // Show an error message against the invalid field.
-                    marketoForm.showErrorMessage(fail.message, fail.element);
-
-                    // Display the field as invalid using the Marketo class.
-                    fail.element.get(0).classList.add('mktoInvalid');
-                } else {
-
-                    // All is good, continue as normal.
-                    marketoForm.submittable(true);
-                }
-            }
-        });
-    });</script>
+    </script>
 </div>
 <!-- End Marketo Signup Form -->

--- a/_includes/trialpopup.html
+++ b/_includes/trialpopup.html
@@ -1,5 +1,3 @@
-<script src="//content.red-gate.com/js/forms2/js/forms2.min.js"></script>
-
 <div class="modal fade" id="flyway-trial-license-modal" tabindex="-1" role="dialog">
     <div class="modal-dialog" role="document">
         <div class="modal-content">
@@ -15,79 +13,86 @@
     </div>
 </div>
 
-<script>MktoForms2.loadForm("//content.red-gate.com", "808-ITG-788", 2819, function(marketoForm) {
-
-    // Update the checkbox label(s).
-    var form = marketoForm.getFormElem().get(0);
-    var checkboxes = form.querySelectorAll('[type="checkbox"]');
-    for (var i=0; i<checkboxes.length; i++) {
-        var checkbox = checkboxes[i];
-        var labels = form.querySelectorAll('label[for="' + checkbox.getAttribute('name') + '"]');
-        var labelText = labels[0].innerText.replace('*', '');
-        for (var l=0; l<labels.length; l++) {
-            labels[l].innerText = labelText;
-        }
-        labels[0].parentElement.removeChild(labels[0]);
-    }
-
-    // On a successful submission, hide and submit trial form.
-    marketoForm.onSuccess(function(formData) {
-        // Wait a second to give Marketo time to enter the person into the database
-        // before doing the POST request in hideAndSubmitTrialForm().
-        window.setTimeout(function(){
-            hideAndSubmitTrialForm(formData);
-        }, 2000);
-        
-        return false;
-    });
-
-    marketoForm.onValidate(function(successful) {
-        if (!successful) {
-            marketoForm.submittable(false);
-        } else {
-
-            // Do some custom validation.
-
-            // Get the fields and their values from the form.
-            var fields = marketoForm.vals();
-
-            // Custom object for storing info about the fail.
-            var fail = {
-                isFail: false,
-                message: '',
-                element: null,
-            };
-
-            // Email validation.
-            if (typeof fields.Email !== 'undefined') {
-
-                // Email regex provided by https://regex101.com/r/L9Z2N0/1.
-                // Check that the format is {something}@{something}.{something}.
-                var emailRegex = /\S+@\S+\.\S+/;
-
-                if (emailRegex.test(fields.Email) === false) {
-                    fail.isFail = true;
-                    fail.message = 'Please enter a valid email address.';
-                    fail.element = marketoForm.getFormElem().find('input[name="Email"]');
+<script>
+    window.addEventListener('load', function() {
+        window.Redgate.Marketo.create({
+            formId: 2819,
+            callback: function(marketoForm) {
+                // Update the checkbox label(s).
+                var form = marketoForm.getFormElem().get(0);
+                var checkboxes = form.querySelectorAll('[type="checkbox"]');
+                for (var i=0; i<checkboxes.length; i++) {
+                    var checkbox = checkboxes[i];
+                    var labels = form.querySelectorAll('label[for="' + checkbox.getAttribute('name') + '"]');
+                    var labelText = labels[0].innerText.replace('*', '');
+                    for (var l=0; l<labels.length; l++) {
+                        labels[l].innerText = labelText;
+                    }
+                    labels[0].parentElement.removeChild(labels[0]);
                 }
-            }
+            
+                // On a successful submission, hide and submit trial form.
+                marketoForm.onSuccess(function(formData) {
+                    // Wait a second to give Marketo time to enter the person into the database
+                    // before doing the POST request in hideAndSubmitTrialForm().
+                    window.setTimeout(function(){
+                        hideAndSubmitTrialForm(formData);
+                    }, 2000);
+                    
+                    return false;
+                });
+            
+                marketoForm.onValidate(function(successful) {
+                    if (!successful) {
+                        marketoForm.submittable(false);
+                    } else {
+            
+                        // Do some custom validation.
+            
+                        // Get the fields and their values from the form.
+                        var fields = marketoForm.vals();
+            
+                        // Custom object for storing info about the fail.
+                        var fail = {
+                            isFail: false,
+                            message: '',
+                            element: null,
+                        };
+            
+                        // Email validation.
+                        if (typeof fields.Email !== 'undefined') {
+            
+                            // Email regex provided by https://regex101.com/r/L9Z2N0/1.
+                            // Check that the format is {something}@{something}.{something}.
+                            var emailRegex = /\S+@\S+\.\S+/;
+            
+                            if (emailRegex.test(fields.Email) === false) {
+                                fail.isFail = true;
+                                fail.message = 'Please enter a valid email address.';
+                                fail.element = marketoForm.getFormElem().find('input[name="Email"]');
+                            }
+                        }
+            
+                        // If form validation fails.
+                        if (fail.isFail) {
+            
+                            // Stop the form from being submittable.
+                            marketoForm.submittable(false);
+            
+                            // Show an error message against the invalid field.
+                            marketoForm.showErrorMessage(fail.message, fail.element);
+            
+                            // Display the field as invalid using the Marketo class.
+                            fail.element.get(0).classList.add('mktoInvalid');
+                        } else {
+            
+                            // All is good, continue as normal.
+                            marketoForm.submittable(true);
+                        }
+                    }
+                });
 
-            // If form validation fails.
-            if (fail.isFail) {
-
-                // Stop the form from being submittable.
-                marketoForm.submittable(false);
-
-                // Show an error message against the invalid field.
-                marketoForm.showErrorMessage(fail.message, fail.element);
-
-                // Display the field as invalid using the Marketo class.
-                fail.element.get(0).classList.add('mktoInvalid');
-            } else {
-
-                // All is good, continue as normal.
-                marketoForm.submittable(true);
-            }
-        }
+            },
+        });
     });
-});</script>
+</script>

--- a/_layouts/default-honeycomb.html
+++ b/_layouts/default-honeycomb.html
@@ -62,7 +62,6 @@
             top.location = self.location;
         }
     </script>
-    <script src="/assets/jquery-1.12.1/jquery-1.12.1.min.js" type="text/javascript"></script>
 </head>
 
 <body class="{{layout.tab}} {{page.tab}}">
@@ -90,6 +89,7 @@
 
 {% include footer-honeycomb.html %}
 
+<script src="/assets/jquery-1.12.1/jquery-1.12.1.min.js" type="text/javascript"></script>
 <script src="/assets/bootstrap-3.3.6-dist/js/bootstrap.min.js" type="text/javascript"></script>
 <script src="/assets/prettify-20110601/prettify.js" type="text/javascript"></script>
 <script src="/assets/toc.js" type="text/javascript"></script>

--- a/_layouts/default-honeycomb.html
+++ b/_layouts/default-honeycomb.html
@@ -51,72 +51,7 @@
 
 {% include footer-honeycomb.html %}
 
-<script src="/assets/jquery-1.12.1/jquery-1.12.1.min.js" type="text/javascript"></script>
-<script src="https://flywaydb.org/wp-content/themes/flyway/global.js" type="text/javascript"></script>
-<script src="/assets/bootstrap-3.3.6-dist/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="/assets/prettify-20110601/prettify.js" type="text/javascript"></script>
-<script src="/assets/toc.js" type="text/javascript"></script>
-<script type="text/javascript">
-    $(function () {
-        prettyPrint();
-        $('#toc').toc({ listType: 'ul', noBackToTopLinks: true, showSpeed: 0, headers: 'h2, h3', title: '' });
+{% include footer-javascript.html %}
 
-        $("h2[id],h3[id]").click(function () {
-            window.location.hash = $(this).attr("id");
-        });
-        $("tr[id]>td:first-child").click(function () {
-            window.location.hash = $(this).parent().attr("id");
-        });
-
-        $("a[href^=http]").each(function () {
-            if (this.href.indexOf(location.hostname) == -1) {
-                $(this).attr({
-                    target: "_blank"
-                });
-            }
-        });
-        $('.modal').on('shown.bs.modal', function() {
-            $(this).find('[autofocus]').focus();
-        });
-    });
-
-    if (navigator.platform.indexOf('Win') == -1) {
-        // Not windows
-        // Fix line continuation marks
-        $("pre.console").html(function () {
-            return $(this).html().replace(/\^\n/g, "\\\n");
-        });
-        // And prompt char
-        $("pre.console span").html(function () {
-            return $(this).html().replace("&gt;", "$");
-        });
-    }
-
-    function downloadDeferred(url) {
-        setTimeout(function () {
-            document.location.href = url;
-        }, 1000);
-    }
-
-    function hideAndDownload(id, url) {
-        $(id).modal('hide');
-
-        downloadDeferred("/download/thankyou?dl=" + url);
-    }
-
-    function hideAndSubmitTrialForm(formData) {
-        $.ajax({
-            type: "POST",
-            url: 'https://repo.flywaydb.org/license/trial',
-            data: formData
-        });
-
-        $('#flyway-trial-license-modal').modal('hide');
-    }
-</script>
-
-<!-- Place this tag right after the last button or just before your close body tag. -->
-<script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
-   
 </body>
 </html>

--- a/_layouts/default-honeycomb.html
+++ b/_layouts/default-honeycomb.html
@@ -20,44 +20,6 @@
     <meta property="og:image" content="https://flywaydb.org/assets/logo/flyway-logo-tm.png"/>
     <meta property="fb:admins" content="762307805"/>
     <script type="text/javascript">
-        (function (i, s, o, g, r, a, m) {
-            i['GoogleAnalyticsObject'] = r;
-            i[r] = i[r] || function () {
-                (i[r].q = i[r].q || []).push(arguments)
-            }, i[r].l = 1 * new Date();
-            a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0];
-            a.async = 1;
-            a.src = g;
-            m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
-
-        ga('create', 'UA-8034033-6', 'flywaydb.org');
-        ga('set', 'forceSSL', true);
-        ga('set', 'anonymizeIp', true);
-        ga('send', 'pageview');
-    </script>
-    <script type="text/javascript">
-        var didInit = false;
-        function initMunchkin() {
-            if(didInit === false) {
-                didInit = true;
-                Munchkin.init('808-ITG-788');
-            }
-        }
-        var s = document.createElement('script');
-        s.type = 'text/javascript';
-        s.async = true;
-        s.src = '//munchkin.marketo.net/munchkin.js';
-        s.onreadystatechange = function() {
-            if (this.readyState === 'complete' || this.readyState === 'loaded') {
-                initMunchkin();
-            }
-        };
-        s.onload = initMunchkin;
-        document.getElementsByTagName('head')[0].appendChild(s);
-    </script>
-    <script type="text/javascript">
         if (self !== top) {
             top.location = self.location;
         }
@@ -90,6 +52,7 @@
 {% include footer-honeycomb.html %}
 
 <script src="/assets/jquery-1.12.1/jquery-1.12.1.min.js" type="text/javascript"></script>
+<script src="https://flywaydb.org/wp-content/themes/flyway/global.js" type="text/javascript"></script>
 <script src="/assets/bootstrap-3.3.6-dist/js/bootstrap.min.js" type="text/javascript"></script>
 <script src="/assets/prettify-20110601/prettify.js" type="text/javascript"></script>
 <script src="/assets/toc.js" type="text/javascript"></script>
@@ -152,34 +115,8 @@
     }
 </script>
 
-<!-- Twitter universal website tag code -->
-<script>
-    !function(e,t,n,s,u,a){e.twq||(s=e.twq=function(){s.exe?s.exe.apply(s,arguments):s.queue.push(arguments);
-    },s.version='1.1',s.queue=[],u=t.createElement(n),u.async=!0,u.src='//static.ads-twitter.com/uwt.js',
-    a=t.getElementsByTagName(n)[0],a.parentNode.insertBefore(u,a))}(window,document,'script');
-    // Insert Twitter Pixel ID and Standard Event data below
-    twq('init','o3gfe');
-    twq('track','PageView');
-</script>
-<!-- End Twitter universal website tag code -->
-
 <!-- Place this tag right after the last button or just before your close body tag. -->
 <script async defer id="github-bjs" src="https://buttons.github.io/buttons.js"></script>
-
-<script type="text/javascript">
-    _linkedin_partner_id = "36413";
-    window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
-    window._linkedin_data_partner_ids.push(_linkedin_partner_id);
-    </script><script type="text/javascript">
-    (function(){var s = document.getElementsByTagName("script")[0];
-    var b = document.createElement("script");
-    b.type = "text/javascript";b.async = true;
-    b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
-    s.parentNode.insertBefore(b, s);})();
-    </script>
-<noscript>
-    <img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=36413&fmt=gif" />
-</noscript>
-    
+   
 </body>
 </html>


### PR DESCRIPTION
This PR updates the GitHub pages part of the site (Documentation) to use the 'global' JavaScripts that have been compiled as part of https://github.com/red-gate/flyway-website/pull/37 (which has now been deployed).

I recently ran an audit across the 2 parts of the website (Wordpress and GitHub pages) and noticed that there were duplicate scripts running on both. I've separated out the duplicate scripts into the 'global' JavaScript on the Wordpress part of the website, and this PR removes the duplicate script references from this codebase.

The global JavaScripts include:
* Google Analytics
* Marketo forms and Munchkin (Marketo tracking)
* Twitter Universal analytics
* 6sense analytics
* LinkedIn analytics

After referencing the global JavaScripts the Marketo forms API has been changed, so I've also updated those references to work as expected.

I've also moved the JavaScript references into an include, rather than keeping them dotted about in the global template file.

Once this PR has been approved and merged, I'll look into creating a global cookie consent module/component (similar to that on red-gate.com) that can be shared across both codebases (in the global JavaScript) to ensure we comply with cookie consent legislation.