### PR TITLE
Add docs page for the `flywayhub` command line

### DIFF
--- a/_layouts/documentation.html
+++ b/_layouts/documentation.html
@@ -271,6 +271,9 @@ title: Documentation
                             {% if page.menu == 'hub_checks' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/hub-checks">Migration script checks</a></li>
                             <li
+                            {% if page.menu == 'hub_commandline' %} class="nav--vertical__active" {% endif %}>
+                              <a href="/documentation/hub-commandline">Command line</a></li>
+                            <li
                             {% if page.menu == 'hub_automation' %} class="nav--vertical__active" {% endif %}>
                             <a href="/documentation/hub-automation">Automation</a></li>
                             <li

--- a/documentation/hub/automation.md
+++ b/documentation/hub/automation.md
@@ -23,13 +23,11 @@ By default with this workflow, your migration script checks will run as a <a hre
 
 ## Other CI Tools
 
-If you do not wish to use GitHub Actions to automate your migration script checks, it is possible to use another CI tool.
+If you do not wish to use GitHub Actions to automate your migration script checks, it is possible to use another CI tool by scripting the <a href="/documentation/hub/commandline">`flywayhub` command line</a>.
 
-This <a href="https://github.com/red-gate/flyway-hub-migration-test/blob/main/entrypoint.sh">script</a> can be added as a step in your CI provider, which will run your migration script checks and report success or failure. The script requires the following to run:
+To give you an idea of how the the `flywayhub` command line can be used in your CI process, take a look at the <a href="https://github.com/red-gate/flyway-hub-migration-test/blob/main/entrypoint.sh">implementation</a> of the Flyway Hub Github Action. Ths script requires the following to run:
 
-- **Environment variable**: `FLYWAY_HUB_ACCESS_TOKEN` - An access token for Flyway Hub creating by clicking "Configure automated checks".
-- **Environment variable**: `GITHUB_SHA` - The commit SHA that triggered the workflow. For example, *ffac537e6cbbf934b08745a378932722df287a53*
-- **Script argument**: `Project ID` - The ID of your Flyway Hub project, found in the URL when viewing a project
+- **Environment variable**: `FLYWAYHUB_ACCESS_TOKEN` - An access token for Flyway Hub creating by clicking "Configure automated checks".
 
 Would you like to see Flyway Hub integrated into your CI provider? <a href="mailto:flywayhub@red-gate.com">Let us know</a>
 

--- a/documentation/hub/automation.md
+++ b/documentation/hub/automation.md
@@ -25,7 +25,7 @@ By default with this workflow, your migration script checks will run as a <a hre
 
 If you do not wish to use GitHub Actions to automate your migration script checks, it is possible to use another CI tool by scripting the <a href="/documentation/hub/commandline">`flywayhub` command line</a>.
 
-To give you an idea of how the the `flywayhub` command line can be used in your CI process, take a look at the <a href="https://github.com/red-gate/flyway-hub-migration-test/blob/main/entrypoint.sh">implementation</a> of the Flyway Hub Github Action. Ths script requires the following to run:
+To give you an idea of how the the `flywayhub` command line can be used in your CI process, take a look at the <a href="https://github.com/red-gate/flyway-hub-migration-test/blob/main/entrypoint.sh">implementation</a> of the Flyway Hub Github Action. This script requires the following to run:
 
 - **Environment variable**: `FLYWAYHUB_ACCESS_TOKEN` - An access token for Flyway Hub creating by clicking "Configure automated checks".
 

--- a/documentation/hub/checks.md
+++ b/documentation/hub/checks.md
@@ -37,5 +37,5 @@ When creating a new project in Flyway Hub, we will do our best to automatically 
 
 Once you have a project created, you can easily <a href="/documentation/hub/automation">automate</a> the checks.
 
-<a href="/documentation/hub/automation"
-        class="btn btn-primary">Automation <i class="fa fa-arrow-right"></i></a>
+<a href="/documentation/hub/commandline"
+        class="btn btn-primary">Command line <i class="fa fa-arrow-right"></i></a>

--- a/documentation/hub/commandline.md
+++ b/documentation/hub/commandline.md
@@ -1,0 +1,81 @@
+---
+layout: documentation
+menu: hub_commandline
+subtitle: Using the `flywayhub` command line
+redirect_from: /documentation/hub-commandline
+---
+
+# Using the `flywayhub` command line
+
+In addition to the <a href="hub.flywaydb.org">Flyway Hub UI</a>, Flyway Hub also offers a command line based workflow for running migration script tests against our ephemeral database instances.
+
+To get started with the `flywayhub` command line, download and install the right version for your platform following the <a href="https://hub.flywaydb.org/projects/new/integration">instructions on Flyway Hub</a>.
+
+## Authentication
+
+Before running tests users first need to authenticate with Flyway Hub using the `flywayhub auth` command:
+
+```
+flywayhub auth
+```
+
+This will open a browser window with a code displayed. Hit 'Submit' and return to the terminal.
+
+## Running tests
+
+The `flywayhub test` command allows you to run your migration scripts from the command line against an automatically provisioned, ephemeral database instance. This functionality mirrors what you can do in the Flyway Hub UI with the 'Run checks' button on the project view.
+
+For example:
+
+```
+flywayhub test --project myproject --engine 'PostgreSQL (v13.2)' ./sql
+```
+
+will do the following steps in order:
+
+1. Provision a fresh Postgres v13.2 instance in the cloud with an empty database.
+2. Use `flyway migrate` to run the migration scripts in `./sql` against the newly provisioned database.
+3. Optionally, run <a href="https://www.sqlfluff.com/">sqlfluff</a> against the migrations in `./sql` to produce a linting report. This step is skipped if `sqlfluff` is not installed on your system.
+4. Upload the results of the migration (and linting) to Flyway Hub.
+5. Tear down the database instance.
+
+## Hard coded database names
+
+While not recommended, it is possible for Flyway migration scripts to contain references to specific database names. In this case, the migrations will only run against a database of that name. To support this use case, provide the `--database` flag to the `flywayhub` command. For example:
+
+```
+flywayhub test --project myproject --engine 'SQL Server (v2017)' --database mydatabase ./sql
+```
+
+This will ensure that your migrations run against a database called 'mydatabase' by creating an empty database of that name in the automatically provisioned instance.
+
+## Flyway config files
+
+Using the `--flywayconf` flag, it is possible to supply the `flyway.conf` file that your project uses to the `flywayhub` command. This might be necessary if you have defined placeholder values, for example. Running:
+
+```
+flywayhub test --project myproject --engine 'SQL Server (v2017)' --flywayconf path/to/flyway.conf ./sql
+```
+
+Ensures that your `flyway.conf` file will be used for the test run.
+
+## Supported engines
+
+Flyway Hub supports the following database engines and versions. These strings are the valid arguments for the `--engine` flag:
+
+* 'SQL Server (v2017)'
+* 'SQL Server (v2019)'
+* 'PostgreSQL (v11.0)'
+* 'PostgreSQL (v12.0)'
+* 'PostgreSQL (v13.2)'
+* 'MySQL (v5.7)'
+* 'MySQL (v8.0)'
+* 'MariaDB (v10.6)'
+
+## Automation
+
+The `flywayhub` CLI is a key component when using Flyway Hub in automation settings like CI pipelines. The next section describes how to set up automation using Flyway Hub to test your migrations on every commit.
+
+<a href="/documentation/hub/automation"
+        class="btn btn-primary">Automation <i class="fa fa-arrow-right"></i></a>
+


### PR DESCRIPTION
Add a new page to the 'Flyway Hub' section on the docs site for the `flywayhub` command line.