### PR TITLE
Organising Flyway tiers

### DIFF
--- a/_includes/enterprise.html
+++ b/_includes/enterprise.html
@@ -1,1 +1,1 @@
-<a href="mailto:sales@flywaydb.org?subject=Secrets%20management%20feature%20with%20Flyway" class="label label-primary" title="Contact sales">Contact sales <i class="fa fa-arrow-right"></i></a>
+<a href="mailto:sales@flywaydb.org?subject=Flyway%20enquiry" class="label label-primary" title="Contact sales">Contact us <i class="fa fa-arrow-right"></i></a>

--- a/_includes/enterprise.html
+++ b/_includes/enterprise.html
@@ -1,0 +1,1 @@
+<a href="mailto:sales@flywaydb.org?subject=Secrets%20management%20feature%20with%20Flyway" class="label label-primary" title="Contact sales">Contact sales <i class="fa fa-arrow-right"></i></a>

--- a/documentation/configuration/secretsManagement.md
+++ b/documentation/configuration/secretsManagement.md
@@ -5,7 +5,7 @@ subtitle: Secrets Management
 redirect_from: /documentation/awsSecretsManager/
 ---
 # Secrets Management
-{% include teams.html %}
+{% include enterprise.html %}
 
 A problem that organizations often encounter is where to store and how to access sensitive data such as the credentials for connecting to a database or their Flyway license key.
 

--- a/documentation/database/mysql.md
+++ b/documentation/database/mysql.md
@@ -10,8 +10,8 @@ subtitle: MySQL
 - `8.0`
 - `5.7` {% include teams.html %}
 - `5.6` {% include teams.html %}
-- `5.5` {% include teams.html %}
-- `5.1` {% include teams.html %}
+- `5.5` {% include enterprise.html %}
+- `5.1` {% include enterprise.html %}
 
 ## Support Level
 

--- a/documentation/database/oracle.md
+++ b/documentation/database/oracle.md
@@ -11,10 +11,10 @@ subtitle: Oracle
 - `18.3`
 - `12.2`
 - `12.1` {% include teams.html %}
-- `11.2` {% include teams.html %}
-- `11.1` {% include teams.html %}
-- `10.2` {% include teams.html %}
-- `10.1` {% include teams.html %}
+- `11.2` {% include enterprise.html %}
+- `11.1` {% include enterprise.html %}
+- `10.2` Unsupported {% include enterprise.html %}
+- `10.1` Unsupported {% include enterprise.html %}
 
 All editions are supported, including XE.
 

--- a/documentation/database/postgresql.md
+++ b/documentation/database/postgresql.md
@@ -17,8 +17,8 @@ subtitle: PostgreSQL
 - `9.4` {% include teams.html %}
 - `9.3` {% include teams.html %}
 - `9.2` {% include teams.html %}
-- `9.1` {% include teams.html %}
-- `9.0` {% include teams.html %}
+- `9.1` {% include enterprise.html %}
+- `9.0` {% include enterprise.html %}
 
 ## Support Level
 

--- a/documentation/database/sqlserver.md
+++ b/documentation/database/sqlserver.md
@@ -12,8 +12,8 @@ subtitle: SQL Server
 - `2016` {% include teams.html %}
 - `2014` {% include teams.html %}
 - `2012` {% include teams.html %}
-- `2008 R2` {% include teams.html %}
-- `2008` {% include teams.html %}
+- `2008 R2` {% include enterprise.html %}
+- `2008` {% include enterprise.html %}
 
 ## Support Level
 


### PR DESCRIPTION
This PR makes some changes about what's included in each of the tiers of Flyway (Tier 1: Community; Tier 2: Teams, Tier 3; coming soon). It:

+ Enables a support option for database releases *over* 10 years 
+ Includes Secrets Management in the enterprise tier  