### PR TITLE
Fix: Include documentation about needing to use buildscript for gradle plugins

### DIFF
--- a/documentation/usage/gradle/index.md
+++ b/documentation/usage/gradle/index.md
@@ -194,6 +194,13 @@ buildscript {
 }
 ```
 
+Signs that you're running into this might be seeing errors like the following:
+
+```
+Caused by: org.flywaydb.core.api.FlywayException: Error occurred while executing flywayValidate
+No database found to handle jdbc:cloudspanner:/projects/my-project/instances/dev/databases/database-name?credentials=/tmp/.appcreds.json
+```
+
 ### Working directory
 
 Some databases can take a relative path inside the JDBC url (such as to specify a file to write to). When running the Flyway gradle plugin, this is relative to `~/.gradle/` not the configuration location. This may not be what you expected, so you may want to specify the path more explicitly such as in the following example:

--- a/documentation/usage/gradle/index.md
+++ b/documentation/usage/gradle/index.md
@@ -178,8 +178,9 @@ For details on how to setup and use custom Gradle configurations, see the [offic
 
 ### Using Flyway Database Types
 
-For some Flyway database types, like [Cloud Spanner](/documentation/database/cloud-spanner) or [SQL Server](/documentation/database/sqlserver), you'll need to actually use a `buildScript` to get your
-Gradle commands to work properly.
+For some Flyway database types (non core), like [Cloud Spanner](/documentation/database/cloud-spanner) or [SQL Server](/documentation/database/sqlserver), you'll need to actually use a `buildScript` to get your
+Gradle commands to work properly. You need to enable putting the database type on the build classpath, and not
+the project classpath.
 
 Something like the following should have you set:
 

--- a/documentation/usage/gradle/index.md
+++ b/documentation/usage/gradle/index.md
@@ -176,13 +176,11 @@ flyway {
 
 For details on how to setup and use custom Gradle configurations, see the [official Gradle documentation](https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html).
 
-### Using Flyway Database Types
+### Adding dependencies on Flyway Database Types
 
-For some Flyway database types (non core), like [Cloud Spanner](/documentation/database/cloud-spanner) or [SQL Server](/documentation/database/sqlserver), you'll need to actually use a `buildScript` to get your
-Gradle commands to work properly. You need to enable putting the database type on the build classpath, and not
-the project classpath.
+For some Flyway database types, like [Cloud Spanner](/documentation/database/cloud-spanner) and [SQL Server](/documentation/database/sqlserver), you'll need to add a dependency to the database type in a `buildscript` closure to get your Gradle commands to work properly. This puts the database type on the build classpath, and not the project classpath.
 
-Something like the following should have you set:
+Here is an example `build.gradle`:
 
 ```groovy
 buildscript {
@@ -190,17 +188,12 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath "org.flywaydb:flyway-mysql:${flywayVersion}"
+        classpath "org.flywaydb:flyway-mysql:{{ site.flywayVersion }} "
     }
 }
 ```
 
-Signs that you're running into this might be seeing errors like the following:
-
-```
-Caused by: org.flywaydb.core.api.FlywayException: Error occurred while executing flywayValidate
-No database found to handle jdbc:cloudspanner:/projects/my-project/instances/dev/databases/database-name?credentials=/tmp/.appcreds.json
-```
+Without this you may see an error like the following: `No database found to handle jdbc:...`
 
 ### Working directory
 

--- a/documentation/usage/gradle/index.md
+++ b/documentation/usage/gradle/index.md
@@ -176,6 +176,24 @@ flyway {
 
 For details on how to setup and use custom Gradle configurations, see the [official Gradle documentation](https://docs.gradle.org/current/dsl/org.gradle.api.artifacts.ConfigurationContainer.html).
 
+### Using Flyway Database Types
+
+For some Flyway database types, like [Cloud Spanner](/documentation/database/cloud-spanner) or [SQL Server](/documentation/database/sqlserver), you'll need to actually use a `buildScript` to get your
+Gradle commands to work properly.
+
+Something like the following should have you set:
+
+```groovy
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath "org.flywaydb:flyway-mysql:${flywayVersion}"
+    }
+}
+```
+
 ### Working directory
 
 Some databases can take a relative path inside the JDBC url (such as to specify a file to write to). When running the Flyway gradle plugin, this is relative to `~/.gradle/` not the configuration location. This may not be what you expected, so you may want to specify the path more explicitly such as in the following example:


### PR DESCRIPTION
# Motivation

Spent an inordinate amount of time trying to get Cloud Spanner working alongside some custom socket stuff we needed to do for GCP's Cloud SQL IAM authentication. We wanted to use the same Gradle commands to make sure everything stayed in line with one another, and we were exercising the same code paths more frequently.

Unfortunately, Gradle is not my native tongue, and while I _knew_ that errors like the following _had_ to be related to the classpath, I couldn't for the life of me figure out how to resolve this, nor why the regular CLI worked out of the box just fine.

```
Caused by: org.flywaydb.core.api.FlywayException: Error occurred while executing flywayValidate
No database found to handle jdbc:cloudspanner:/projects/my-project/instances/dev/databases/database-name?credentials=/tmp/.appcreds.json
	at org.flywaydb.gradle.task.AbstractFlywayTask.runTask(AbstractFlywayTask.java:678)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
```

Eventually found [this comment in Github](https://github.com/flyway/flyway/issues/3355#issuecomment-1000585918) which solved everything. I'd like to think that had this existed in the documentation, I'd have gotten it on the first try 🤷 

## Notes

I am _sure_ my documentation here is prolly very off/I'm referring to things incorrectly in the Gradle sense. Happy to change things. Maybe @DoodleBobBuffPants has some thoughts on how to make this clearer (I simply copied their snippet afterall 😅 )

## Thank you!

Have used Flyway for years, love the tool. Thanks folks!