### PR TITLE
Update loggers.md for typo

### DIFF
--- a/documentation/configuration/parameters/loggers.md
+++ b/documentation/configuration/parameters/loggers.md
@@ -63,6 +63,6 @@ flyway {
 ### Maven
 ```xml
 <configuration>
-    <loggers>auto</lockRetryCount>
+    <loggers>auto</loggers>
 </configuration>
 ```


### PR DESCRIPTION
change maven configuration from:

`<loggers>auto</lockRetryCount>`

to：

`<loggers>auto</loggers>`
