### PR TITLE
fix postgresqlTransactionalLock gradle config example

### DIFF
--- a/documentation/configuration/parameters/baselineMigrationPrefix.md
+++ b/documentation/configuration/parameters/baselineMigrationPrefix.md
@@ -44,7 +44,7 @@ baselineMigrationConfigurationExtension.setBaselineMigrationPrefix("IB");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
       baselineMigrationPrefix: 'IB'
     ]
 }

--- a/documentation/configuration/parameters/daprSecrets.md
+++ b/documentation/configuration/parameters/daprSecrets.md
@@ -41,7 +41,7 @@ daprConfigurationExtension.setDaprSecrets("secret1", "secret2");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         daprSecrets: ['secret1', 'secret2']
     ]
 }

--- a/documentation/configuration/parameters/daprUrl.md
+++ b/documentation/configuration/parameters/daprUrl.md
@@ -39,7 +39,7 @@ daprConfigurationExtension.setDaprUrl("http://localhost:3500/v1.0/secrets/my-sec
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         daprUrl: 'http://localhost:3500/v1.0/secrets/my-secrets-store'
     ]
 }

--- a/documentation/configuration/parameters/gcsmProject.md
+++ b/documentation/configuration/parameters/gcsmProject.md
@@ -39,7 +39,7 @@ gcsmConfigurationExtension.setGcsmProject("quixotic-ferret-345678");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         gcsmProject: 'quixotic-ferret-345678'
     ]
 }

--- a/documentation/configuration/parameters/gcsmSecrets.md
+++ b/documentation/configuration/parameters/gcsmSecrets.md
@@ -39,7 +39,7 @@ gcsmConfigurationExtension.setGcsmSecrets("secret1", "secret2");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         gcsmSecrets: ['secret1', 'secret2']
     ]
 }

--- a/documentation/configuration/parameters/postgresqlTransactionalLock.md
+++ b/documentation/configuration/parameters/postgresqlTransactionalLock.md
@@ -41,8 +41,8 @@ configurationExtension.setTransactionalLock(false);
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
-      postgresqlTransactionalLock: false
+    pluginConfiguration = [
+      postgresqlTransactionalLock: 'false'
     ]
 }
 ```

--- a/documentation/configuration/parameters/sqlServerKerberosLoginFile.md
+++ b/documentation/configuration/parameters/sqlServerKerberosLoginFile.md
@@ -37,7 +37,7 @@ sqlServerConfigurationExtension.setKerberosLoginFile("/path/to/SQLJDBCDriver.con
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
         sqlserverKerberosLoginFile: '/path/to/SQLJDBCDriver.conf'
     ]
 }

--- a/documentation/configuration/parameters/vaultSecrets.md
+++ b/documentation/configuration/parameters/vaultSecrets.md
@@ -42,7 +42,7 @@ vaultConfigurationExtension.setVaultSecrets("kv/data/flyway/flywayConfig1", "kv/
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
       vaultSecrets: ['kv/data/flyway/flywayConfig1', 'kv/flyway/flywayConfig2']
     ]
 }

--- a/documentation/configuration/parameters/vaultToken.md
+++ b/documentation/configuration/parameters/vaultToken.md
@@ -37,7 +37,7 @@ vaultConfigurationExtension.setVaultToken("s.abcdefghijklmnopqrstuvwx");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
       vaultToken: 's.abcdefghijklmnopqrstuvwx'
     ]
 }

--- a/documentation/configuration/parameters/vaultUrl.md
+++ b/documentation/configuration/parameters/vaultUrl.md
@@ -39,7 +39,7 @@ vaultConfigurationExtension.setVaultUrl("http://localhost:8200/v1/");
 ### Gradle
 ```groovy
 flyway {
-    pluginConfiguration [
+    pluginConfiguration = [
       vaultUrl: 'http://localhost:8200/v1/'
     ]
 }


### PR DESCRIPTION
This commit corrects a couple of problems with the gradle example in the `postgresqlTransactionalLock` documentation.

Without the change to line 44, gradle is unable to compile the build script, reporting:
> You tried to use a map entry for an index operation, this is not allowed. Maybe something should be set in parentheses or a comma is missing?

Without the change to line 45, the `flywayMigrate` task fails with:
> class java.lang.Boolean cannot be cast to class java.lang.String (java.lang.Boolean and java.lang.String are in module java.base of loader 'bootstrap')